### PR TITLE
Rebrand, improve scrolling, add drag and drop, added menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,178 @@
-# spanwright
-Spanwright: Multi-Monitor Wallpaper Alignment Tool
+# Spanwright — Multi-Monitor Wallpaper Alignment Tool
+
+Spanwright is a single-page web app that lets you create pixel-perfect spanning wallpapers for non-standard multi-monitor setups. Windows' "span" wallpaper mode concatenates monitors by pixel resolution, ignoring physical size differences — Spanwright solves this by letting you model your physical desk layout, position a source image across it, and export a stitched wallpaper that looks seamless when spanned.
+
+## The Problem
+
+If you have monitors of different sizes or resolutions (e.g., a 15.6" laptop next to a 27" QHD desktop), Windows span mode produces misaligned wallpapers. A single wide image gets split based on raw pixel counts, not physical dimensions. A mountain peak that should flow across both screens ends up with a jarring offset.
+
+Spanwright operates in **physical space** (inches/cm), so you arrange monitors as they actually sit on your desk. It then renders each monitor's portion of the source image at the correct PPI, producing one output image that Windows can span correctly.
+
+## Features
+
+- **Physical-space monitor layout** — Arrange monitors on a canvas using real-world dimensions (calculated from diagonal size + resolution). A 27" monitor appears physically larger than a 15.6" laptop, exactly as on your desk.
+- **Drag-and-drop presets** — Choose from 18+ built-in monitor presets (laptops, standard monitors, ultrawides, super ultrawides) and drag them directly onto the canvas.
+- **Custom monitors** — Define any monitor by diagonal size, aspect ratio, and resolution. Supports fully custom resolution entry or filtered presets by aspect ratio.
+- **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display.
+- **Smart image recommendations** — Calculates the minimum source image resolution needed based on your layout's physical size and the highest-PPI monitor.
+- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches the results side-by-side. Handles vertical offsets and fills empty space with black.
+- **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
+- **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom, right-click drag to pan. Custom scrollbars, snap-to-grid, and fit-to-view.
+- **Unit toggle** — Switch between inches and centimeters.
+
+## Getting Started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+ (LTS recommended)
+- npm, yarn, or pnpm
+
+### Installation
+
+```bash
+git clone https://github.com/your-username/spanwright.git
+cd spanwright
+npm install
+```
+
+### Development
+
+```bash
+npm run dev
+```
+
+Opens at [http://localhost:5173](http://localhost:5173) by default.
+
+### Build for Production
+
+```bash
+npm run build
+```
+
+Output is in the `dist/` folder, ready for static hosting (e.g., Vercel, Netlify, GitHub Pages).
+
+### Preview Production Build
+
+```bash
+npm run preview
+```
+
+## How to Use
+
+### 1. Add Monitors
+
+Use the sidebar on the left to add monitors to the canvas:
+
+- **Click** a preset to add it at a default position
+- **Drag** a preset directly onto the canvas to place it where you want
+- **Custom monitors**: Click "+ Custom Monitor" to define a monitor by diagonal size, aspect ratio, and resolution
+
+### 2. Arrange Your Layout
+
+Drag monitors on the canvas to match your physical desk arrangement:
+
+- Position your laptop screen lower-left, your main monitor centered, etc.
+- The canvas uses physical dimensions — a 27" monitor will appear larger than a 13" laptop
+- Enable **Snap to Grid** in the toolbar for precise alignment
+- Click a monitor and press **Delete** to remove it
+- Press **F** to fit all monitors in view
+
+### 3. Upload & Position Your Image
+
+- Drag and drop an image file onto the canvas, or use the upload button in the toolbar
+- The image appears behind the monitors with 70% opacity
+- **Drag** the image to reposition it
+- **Click** the image and use the corner handles to resize it
+- Check the **recommended image size** banner in the toolbar — green means your image is large enough, yellow/red means it may appear pixelated
+
+### 4. Preview & Export
+
+- The bottom panel shows a live preview of the final stitched wallpaper
+- Click **Download** to save as PNG or JPEG
+- The output dimensions are displayed (e.g., "7280 x 1440")
+
+### 5. Set as Windows Wallpaper
+
+1. Download the generated image
+2. Open **Settings > Personalization > Background**
+3. Set "Choose a fit" to **Span**
+4. Select the downloaded image
+
+> **Important:** Make sure your Windows display arrangement (Settings > Display) matches the physical layout you configured in Spanwright.
+
+## Canvas Controls
+
+| Action | Control |
+|--------|---------|
+| Pan | Scroll wheel / Right-click drag |
+| Horizontal pan | Shift + Scroll |
+| Zoom | Ctrl + Scroll |
+| Fit view | Press **F** / click **Fit** button |
+| Select monitor | Click on it |
+| Delete monitor | Select + **Delete** or **Backspace** |
+| Deselect | **Escape** or click empty space |
+
+## How It Works
+
+### Coordinate Spaces
+
+Spanwright operates in two coordinate spaces:
+
+- **Physical space (inches)** — The canvas grid. Monitor sizes and image positioning happen here. 1 canvas unit = 1 physical inch.
+- **Pixel space** — Each monitor's native resolution. The output image lives here.
+
+### PPI Calculation
+
+```
+PPI = sqrt(resolutionX² + resolutionY²) / diagonalInches
+physicalWidth = resolutionX / PPI
+physicalHeight = resolutionY / PPI
+```
+
+For example, a 27" QHD (2560x1440) monitor:
+- PPI = sqrt(2560² + 1440²) / 27 ≈ 109
+- Physical width = 2560 / 109 ≈ 23.5"
+- Physical height = 1440 / 109 ≈ 13.2"
+
+### Output Generation
+
+For each monitor (sorted left-to-right by physical position):
+1. Determine the physical bounding box on the canvas
+2. Find the overlapping region of the source image
+3. Map physical coordinates back to source image pixels
+4. Crop and scale that region to the monitor's native resolution
+5. Stitch all strips side-by-side into the final output
+
+The output height equals the tallest monitor's resolution. Shorter monitors are vertically positioned based on their physical offset, with black fill for empty space.
+
+## Tech Stack
+
+- [React](https://react.dev/) 19 + TypeScript
+- [Konva](https://konvajs.org/) / [react-konva](https://github.com/konvajs/react-konva) for canvas rendering
+- [Tailwind CSS](https://tailwindcss.com/) 4 for styling
+- [Vite](https://vite.dev/) 7 for build tooling
+- No backend — all processing is client-side
+
+## Project Structure
+
+```
+src/
+├── App.tsx                    # Main layout
+├── main.tsx                   # Entry point
+├── store.tsx                  # Global state (useReducer + Context)
+├── types.ts                   # TypeScript interfaces
+├── utils.ts                   # PPI calculations, coordinate math
+├── presets.ts                 # Monitor preset definitions
+├── generateOutput.ts          # Wallpaper stitching logic
+├── index.css                  # Tailwind imports
+└── components/
+    ├── EditorCanvas.tsx       # Interactive canvas editor
+    ├── MonitorPresetsSidebar.tsx  # Preset list + custom form
+    ├── Toolbar.tsx            # Top toolbar controls
+    ├── PreviewPanel.tsx       # Output preview + download
+    └── ImageUpload.tsx        # File upload component
+```
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Wallpaper Resizer — Multi-Monitor Alignment Tool</title>
+    <title>Spanwright — Multi-Monitor Wallpaper Alignment Tool</title>
   </head>
   <body class="bg-gray-950 text-gray-100">
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wallpaper-resizer",
+  "name": "spanwright",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wallpaper-resizer",
+      "name": "spanwright",
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wallpaper-resizer",
+  "name": "spanwright",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,11 @@ export default function App() {
               <path d="M8 21h8M12 17v4" />
             </svg>
             <h1 className="text-sm font-bold text-gray-100 tracking-tight">
-              Wallpaper Resizer
+              Spanwright
             </h1>
           </div>
           <span className="text-xs text-gray-500">
-            Multi-Monitor Alignment Tool
+            Multi-Monitor Wallpaper Alignment Tool
           </span>
         </header>
 

--- a/src/components/MonitorPresetsSidebar.tsx
+++ b/src/components/MonitorPresetsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { MONITOR_PRESETS, COMMON_ASPECT_RATIOS, COMMON_RESOLUTIONS } from '../presets'
 import type { MonitorPreset } from '../types'
 import { useStore } from '../store'
@@ -9,8 +9,43 @@ export default function MonitorPresetsSidebar() {
   const [showCustom, setShowCustom] = useState(false)
   const [customDiagonal, setCustomDiagonal] = useState('27')
   const [customAspect, setCustomAspect] = useState<[number, number]>([16, 9])
-  const [customResIdx, setCustomResIdx] = useState(1)
+  const [customResIdx, setCustomResIdx] = useState(0)
+  const [useCustomRes, setUseCustomRes] = useState(false)
+  const [customResW, setCustomResW] = useState('2560')
+  const [customResH, setCustomResH] = useState('1440')
   const [searchFilter, setSearchFilter] = useState('')
+
+  // Filter resolutions based on selected aspect ratio (with tolerance for rounding)
+  const filteredResolutions = useMemo(() => {
+    const [aw, ah] = customAspect
+    const targetRatio = aw / ah
+    return COMMON_RESOLUTIONS.filter(r => {
+      const resRatio = r.w / r.h
+      return Math.abs(resRatio - targetRatio) / targetRatio < 0.05
+    })
+  }, [customAspect])
+
+  // Reset resolution selection when aspect ratio changes
+  function handleAspectChange(a: number, b: number) {
+    setCustomAspect([a, b])
+    setCustomResIdx(0)
+    setUseCustomRes(false)
+    // Auto-fill custom resolution fields based on first matching resolution
+    const targetRatio = a / b
+    const match = COMMON_RESOLUTIONS.find(r => Math.abs(r.w / r.h - targetRatio) / targetRatio < 0.02)
+    if (match) {
+      setCustomResW(String(match.w))
+      setCustomResH(String(match.h))
+    } else {
+      // No preset resolution for this ratio, auto-switch to custom entry
+      setUseCustomRes(true)
+      // Calculate a reasonable default resolution for this aspect ratio
+      const height = 1440
+      const width = Math.round(height * a / b)
+      setCustomResW(String(width))
+      setCustomResH(String(height))
+    }
+  }
 
   function addPreset(preset: MonitorPreset) {
     // Place at a default position, slightly offset for each new monitor
@@ -19,14 +54,22 @@ export default function MonitorPresetsSidebar() {
   }
 
   function addCustom() {
-    const res = COMMON_RESOLUTIONS[customResIdx]
-    if (!res) return
+    let resW: number, resH: number
+    if (useCustomRes) {
+      resW = parseInt(customResW) || 1920
+      resH = parseInt(customResH) || 1080
+    } else {
+      const res = filteredResolutions[customResIdx]
+      if (!res) return
+      resW = res.w
+      resH = res.h
+    }
     const preset: MonitorPreset = {
-      name: `Custom ${customDiagonal}" ${res.w}x${res.h}`,
-      diagonal: parseFloat(customDiagonal),
+      name: `Custom ${customDiagonal}" ${resW}x${resH}`,
+      diagonal: parseFloat(customDiagonal) || 27,
       aspectRatio: customAspect,
-      resolutionX: res.w,
-      resolutionY: res.h,
+      resolutionX: resW,
+      resolutionY: resH,
     }
     addPreset(preset)
     setShowCustom(false)
@@ -58,13 +101,13 @@ export default function MonitorPresetsSidebar() {
 
       <div className="flex-1 overflow-y-auto p-2 space-y-3">
         {laptops.length > 0 && (
-          <PresetGroup title="Laptops" presets={laptops} onAdd={addPreset} unit={state.unit} />
+          <PresetGroup title="Laptops" presets={laptops} onAdd={addPreset} unit={state.unit} canvasScale={state.canvasScale} />
         )}
         {standard.length > 0 && (
-          <PresetGroup title="Standard Monitors" presets={standard} onAdd={addPreset} unit={state.unit} />
+          <PresetGroup title="Standard Monitors" presets={standard} onAdd={addPreset} unit={state.unit} canvasScale={state.canvasScale} />
         )}
         {ultrawides.length > 0 && (
-          <PresetGroup title="Ultrawides" presets={ultrawides} onAdd={addPreset} unit={state.unit} />
+          <PresetGroup title="Ultrawides" presets={ultrawides} onAdd={addPreset} unit={state.unit} canvasScale={state.canvasScale} />
         )}
       </div>
 
@@ -97,7 +140,7 @@ export default function MonitorPresetsSidebar() {
                 value={`${customAspect[0]}:${customAspect[1]}`}
                 onChange={e => {
                   const [a, b] = e.target.value.split(':').map(Number)
-                  setCustomAspect([a, b])
+                  handleAspectChange(a, b)
                 }}
                 className="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
               >
@@ -108,15 +151,57 @@ export default function MonitorPresetsSidebar() {
             </div>
             <div>
               <label className="text-xs text-gray-500">Resolution</label>
-              <select
-                value={customResIdx}
-                onChange={e => setCustomResIdx(parseInt(e.target.value))}
-                className="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
-              >
-                {COMMON_RESOLUTIONS.map((r, i) => (
-                  <option key={i} value={i}>{r.label}</option>
-                ))}
-              </select>
+              {!useCustomRes && filteredResolutions.length > 0 ? (
+                <>
+                  <select
+                    value={customResIdx}
+                    onChange={e => setCustomResIdx(parseInt(e.target.value))}
+                    className="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+                  >
+                    {filteredResolutions.map((r, i) => (
+                      <option key={i} value={i}>{r.label}</option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={() => setUseCustomRes(true)}
+                    className="text-xs text-blue-400 hover:text-blue-300 mt-1 transition-colors"
+                  >
+                    Enter custom resolution
+                  </button>
+                </>
+              ) : (
+                <>
+                  <div className="flex gap-1.5 items-center">
+                    <input
+                      type="number"
+                      value={customResW}
+                      onChange={e => setCustomResW(e.target.value)}
+                      min="640"
+                      max="15360"
+                      placeholder="Width"
+                      className="flex-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+                    />
+                    <span className="text-xs text-gray-500">x</span>
+                    <input
+                      type="number"
+                      value={customResH}
+                      onChange={e => setCustomResH(e.target.value)}
+                      min="480"
+                      max="8640"
+                      placeholder="Height"
+                      className="flex-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+                    />
+                  </div>
+                  {filteredResolutions.length > 0 && (
+                    <button
+                      onClick={() => { setUseCustomRes(false); setCustomResIdx(0) }}
+                      className="text-xs text-blue-400 hover:text-blue-300 mt-1 transition-colors"
+                    >
+                      Use preset resolution
+                    </button>
+                  )}
+                </>
+              )}
             </div>
             <div className="flex gap-2">
               <button
@@ -139,17 +224,103 @@ export default function MonitorPresetsSidebar() {
   )
 }
 
+const MONITOR_COLORS = [
+  '#3b82f6', '#8b5cf6', '#06b6d4', '#10b981',
+  '#f59e0b', '#ef4444', '#ec4899', '#6366f1',
+]
+
+/**
+ * Build a canvas-based drag image that looks like the monitor rectangle
+ * as it will appear on the editor canvas. Returns the canvas element and
+ * the offset (center point) so the cursor sits in the middle.
+ */
+function buildDragImage(preset: MonitorPreset, index: number, canvasScale: number): { canvas: HTMLCanvasElement; offsetX: number; offsetY: number } {
+  const ppi = calculatePPI(preset.resolutionX, preset.resolutionY, preset.diagonal)
+  const { width: physW, height: physH } = calculatePhysicalDimensions(preset.resolutionX, preset.resolutionY, ppi)
+
+  // Match the canvas zoom scale so the ghost is the same size as on the editor
+  const w = Math.round(physW * canvasScale)
+  const h = Math.round(physH * canvasScale)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = w
+  canvas.height = h
+  // Position off-screen so it doesn't flash when briefly added to the DOM
+  canvas.style.position = 'fixed'
+  canvas.style.top = '-9999px'
+  canvas.style.left = '-9999px'
+
+  const ctx = canvas.getContext('2d')!
+
+  const color = MONITOR_COLORS[index % MONITOR_COLORS.length]
+
+  // Background fill (semi-transparent, like the canvas monitor)
+  ctx.fillStyle = color
+  ctx.globalAlpha = 0.18
+  ctx.beginPath()
+  ctx.roundRect(0, 0, w, h, 3)
+  ctx.fill()
+
+  // Border
+  ctx.globalAlpha = 0.9
+  ctx.strokeStyle = color
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.roundRect(0, 0, w, h, 3)
+  ctx.stroke()
+
+  // Only draw labels if the rectangle is large enough to read them
+  ctx.globalAlpha = 1
+  if (w > 60 && h > 30) {
+    const labelW = Math.min(w - 8, 200)
+    const showDetails = w > 100 && h > 44
+    const labelH = showDetails ? 44 : 28
+    ctx.fillStyle = 'rgba(0,0,0,0.75)'
+    ctx.beginPath()
+    ctx.roundRect(4, 4, labelW, labelH, 3)
+    ctx.fill()
+
+    // Monitor name
+    ctx.fillStyle = '#ffffff'
+    ctx.font = 'bold 11px system-ui, sans-serif'
+    ctx.fillText(preset.name, 8, 16, labelW - 8)
+
+    // Resolution subtitle
+    if (showDetails) {
+      ctx.fillStyle = '#94a3b8'
+      ctx.font = '9px system-ui, sans-serif'
+      ctx.fillText(`${preset.resolutionX}x${preset.resolutionY}  ·  ${Math.round(ppi)} PPI`, 8, 30, labelW - 8)
+    }
+  }
+
+  return { canvas, offsetX: Math.round(w / 2), offsetY: Math.round(h / 2) }
+}
+
 function PresetGroup({
   title,
   presets,
   onAdd,
   unit,
+  canvasScale,
 }: {
   title: string
   presets: MonitorPreset[]
   onAdd: (p: MonitorPreset) => void
   unit: 'inches' | 'cm'
+  canvasScale: number
 }) {
+  const handleDragStart = (e: React.DragEvent, preset: MonitorPreset, index: number) => {
+    e.dataTransfer.setData('application/monitor-preset', JSON.stringify(preset))
+    e.dataTransfer.effectAllowed = 'copy'
+
+    const { canvas, offsetX, offsetY } = buildDragImage(preset, index, canvasScale)
+    // The element must be in the DOM for setDragImage to work in all browsers
+    document.body.appendChild(canvas)
+    e.dataTransfer.setDragImage(canvas, offsetX, offsetY)
+    // Remove after the browser has captured the image
+    requestAnimationFrame(() => document.body.removeChild(canvas))
+  }
+
   return (
     <div>
       <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1 px-1">
@@ -162,8 +333,10 @@ function PresetGroup({
           return (
             <button
               key={`${preset.name}-${i}`}
+              draggable
               onClick={() => onAdd(preset)}
-              className="w-full text-left bg-gray-800 hover:bg-gray-750 hover:bg-gray-700 border border-gray-700 hover:border-gray-600 rounded p-2 transition-colors group"
+              onDragStart={(e) => handleDragStart(e, preset, i)}
+              className="w-full text-left bg-gray-800 hover:bg-gray-750 hover:bg-gray-700 border border-gray-700 hover:border-gray-600 rounded p-2 transition-colors group cursor-grab active:cursor-grabbing"
             >
               <div className="text-sm font-medium text-gray-200 group-hover:text-white">
                 {preset.name}

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -38,12 +38,33 @@ export const COMMON_ASPECT_RATIOS: [number, number][] = [
 ]
 
 export const COMMON_RESOLUTIONS: { label: string; w: number; h: number }[] = [
+  // 16:9
+  { label: '1280 x 720 (HD)', w: 1280, h: 720 },
   { label: '1920 x 1080 (FHD)', w: 1920, h: 1080 },
   { label: '2560 x 1440 (QHD)', w: 2560, h: 1440 },
-  { label: '2560 x 1600 (QHD+)', w: 2560, h: 1600 },
   { label: '3840 x 2160 (4K)', w: 3840, h: 2160 },
+  { label: '5120 x 2880 (5K)', w: 5120, h: 2880 },
+  { label: '7680 x 4320 (8K)', w: 7680, h: 4320 },
+  // 16:10
+  { label: '1280 x 800 (WXGA)', w: 1280, h: 800 },
+  { label: '1920 x 1200 (WUXGA)', w: 1920, h: 1200 },
+  { label: '2560 x 1600 (QHD+)', w: 2560, h: 1600 },
+  { label: '3840 x 2400 (4K+)', w: 3840, h: 2400 },
+  // 21:9
   { label: '2560 x 1080 (UW FHD)', w: 2560, h: 1080 },
   { label: '3440 x 1440 (UW QHD)', w: 3440, h: 1440 },
   { label: '3840 x 1600 (UW QHD+)', w: 3840, h: 1600 },
+  { label: '5120 x 2160 (UW 4K)', w: 5120, h: 2160 },
+  // 32:9
+  { label: '3840 x 1080 (SUW FHD)', w: 3840, h: 1080 },
   { label: '5120 x 1440 (SUW QHD)', w: 5120, h: 1440 },
+  // 3:2
+  { label: '2160 x 1440 (3:2)', w: 2160, h: 1440 },
+  { label: '2256 x 1504 (Surface)', w: 2256, h: 1504 },
+  { label: '3000 x 2000 (3:2 3K)', w: 3000, h: 2000 },
+  { label: '3240 x 2160 (3:2 QHD)', w: 3240, h: 2160 },
+  // 4:3
+  { label: '1024 x 768 (XGA)', w: 1024, h: 768 },
+  { label: '1600 x 1200 (UXGA)', w: 1600, h: 1200 },
+  { label: '2048 x 1536 (QXGA)', w: 2048, h: 1536 },
 ]

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -17,6 +17,7 @@ interface State {
 type Action =
   | { type: 'ADD_MONITOR'; preset: MonitorPreset; x: number; y: number }
   | { type: 'REMOVE_MONITOR'; id: string }
+  | { type: 'CLEAR_ALL_MONITORS' }
   | { type: 'MOVE_MONITOR'; id: string; x: number; y: number }
   | { type: 'SELECT_MONITOR'; id: string | null }
   | { type: 'SET_SOURCE_IMAGE'; image: SourceImage }
@@ -38,7 +39,7 @@ const initialState: State = {
   canvasOffsetY: 50,
   unit: 'inches',
   selectedMonitorId: null,
-  snapToGrid: true,
+  snapToGrid: false,
   gridSize: 1,
 }
 
@@ -54,6 +55,8 @@ function reducer(state: State, action: Action): State {
         monitors: state.monitors.filter(m => m.id !== action.id),
         selectedMonitorId: state.selectedMonitorId === action.id ? null : state.selectedMonitorId,
       }
+    case 'CLEAR_ALL_MONITORS':
+      return { ...state, monitors: [], selectedMonitorId: null }
     case 'MOVE_MONITOR':
       return {
         ...state,
@@ -83,7 +86,7 @@ function reducer(state: State, action: Action): State {
           }
         : state
     case 'SET_CANVAS_SCALE':
-      return { ...state, canvasScale: Math.max(2, Math.min(40, action.scale)) }
+      return { ...state, canvasScale: Math.max(2, Math.min(20, action.scale)) }
     case 'PAN_CANVAS':
       return {
         ...state,


### PR DESCRIPTION
## Summary

Rebrand to **Spanwright** and add several UX improvements to the multi-monitor wallpaper alignment tool.

- **Branding**: Rename from "Wallpaper Resizer" to "Spanwright — Multi-Monitor Wallpaper Alignment Tool" across the page title, header, and package.json
- **Drag-and-drop monitor presets**: Sidebar presets can now be dragged directly onto the canvas, placing the monitor at the drop position. The drag ghost renders as a correctly-proportioned monitor rectangle that matches the current canvas zoom scale.
- **Improved custom monitor form**: Resolution dropdown now filters by selected aspect ratio. Added an "Enter custom resolution" toggle for fully manual width/height pixel input. Expanded preset resolutions from 8 to 23, covering all 6 supported aspect ratios (16:9, 16:10, 21:9, 32:9, 3:2, 4:3).
- **Canvas scroll/zoom overhaul**: Normal scroll now pans (vertical default, horizontal with Shift). Zooming requires Ctrl+Scroll. Added custom scrollbar overlays. Reduced max zoom from 40 to 20 px/in (~50%). Added control hints in the bottom-right corner.
- **Canvas menu**: Added a three-dot dropdown menu in the top-right of the canvas with "Clear all monitors", "Remove image", and "Reset canvas" actions.
- **Snap off by default**: Snap-to-grid is now disabled by default.
- **Comprehensive README**: Added full documentation covering features, installation, usage guide, canvas controls, coordinate-space math, tech stack, and project structure.

## Files changed

- `README.md` — comprehensive project documentation
- `index.html` — title rebrand
- `package.json` — name rebrand
- `src/App.tsx` — header rebrand
- `src/store.tsx` — added `CLEAR_ALL_MONITORS` action, snap default off
- `src/presets.ts` — expanded resolution presets for all aspect ratios
- `src/components/MonitorPresetsSidebar.tsx` — drag-and-drop with canvas-scale ghost, aspect-ratio-filtered resolution dropdown, custom resolution input
- `src/components/EditorCanvas.tsx` — scroll-to-pan / ctrl-to-zoom, custom scrollbars, canvas dropdown menu, monitor preset drop handling