### PR TITLE
Lots of upgrades to UI and added tab for Windows Display Settings adjustment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,90 @@
-import { StoreProvider } from './store'
+import { StoreProvider, useStore } from './store'
 import MonitorPresetsSidebar from './components/MonitorPresetsSidebar'
 import EditorCanvas from './components/EditorCanvas'
 import Toolbar from './components/Toolbar'
 import PreviewPanel from './components/PreviewPanel'
+import WindowsArrangementCanvas from './components/WindowsArrangementCanvas'
+import type { ActiveTab } from './types'
+
+function TabButton({ tab, label, active, onClick }: { tab: ActiveTab; label: string; active: boolean; onClick: (tab: ActiveTab) => void }) {
+  return (
+    <button
+      onClick={() => onClick(tab)}
+      className={`px-4 py-1.5 text-xs font-medium rounded-t transition-colors relative ${
+        active
+          ? 'bg-gray-950 text-gray-100 border-t border-x border-gray-700'
+          : 'bg-gray-900 text-gray-500 hover:text-gray-300 border-t border-x border-transparent'
+      }`}
+    >
+      {label}
+      {active && (
+        <div className="absolute bottom-0 left-0 right-0 h-px bg-gray-950" />
+      )}
+    </button>
+  )
+}
+
+function AppContent() {
+  const { state, dispatch } = useStore()
+  const tab = state.activeTab
+
+  const setTab = (t: ActiveTab) => dispatch({ type: 'SET_ACTIVE_TAB', tab: t })
+
+  return (
+    <div className="h-screen flex flex-col bg-gray-950 text-gray-100 overflow-hidden">
+      {/* Header */}
+      <header className="bg-gray-900 border-b border-gray-800 px-4 py-2.5 flex items-center gap-3 shrink-0">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-blue-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <rect x="2" y="3" width="20" height="14" rx="2" />
+            <path d="M8 21h8M12 17v4" />
+          </svg>
+          <h1 className="text-sm font-bold text-gray-100 tracking-tight">
+            Spanwright
+          </h1>
+        </div>
+        <span className="text-xs text-gray-500">
+          Multi-Monitor Wallpaper Alignment Tool
+        </span>
+      </header>
+
+      {/* Tabs */}
+      <div className="bg-gray-900 border-b border-gray-700 px-4 flex items-end gap-1 shrink-0">
+        <TabButton tab="physical" label="Physical Layout" active={tab === 'physical'} onClick={setTab} />
+        <TabButton tab="windows" label="Windows Arrangement" active={tab === 'windows'} onClick={setTab} />
+        <TabButton tab="preview" label="Preview & Export" active={tab === 'preview'} onClick={setTab} />
+      </div>
+
+      {/* Tab content */}
+      {tab === 'physical' && (
+        <>
+          <Toolbar />
+          <div className="flex flex-1 min-h-0 relative">
+            <EditorCanvas />
+            <MonitorPresetsSidebar />
+          </div>
+        </>
+      )}
+
+      {tab === 'windows' && (
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <WindowsArrangementCanvas />
+        </div>
+      )}
+
+      {tab === 'preview' && (
+        <div className="flex-1 min-h-0 overflow-auto">
+          <PreviewPanel />
+        </div>
+      )}
+    </div>
+  )
+}
 
 export default function App() {
   return (
     <StoreProvider>
-      <div className="h-screen flex flex-col bg-gray-950 text-gray-100 overflow-hidden">
-        {/* Header */}
-        <header className="bg-gray-900 border-b border-gray-800 px-4 py-2.5 flex items-center gap-3 shrink-0">
-          <div className="flex items-center gap-2">
-            <svg className="w-5 h-5 text-blue-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <rect x="2" y="3" width="20" height="14" rx="2" />
-              <path d="M8 21h8M12 17v4" />
-            </svg>
-            <h1 className="text-sm font-bold text-gray-100 tracking-tight">
-              Spanwright
-            </h1>
-          </div>
-          <span className="text-xs text-gray-500">
-            Multi-Monitor Wallpaper Alignment Tool
-          </span>
-        </header>
-
-        {/* Toolbar */}
-        <Toolbar />
-
-        {/* Main editor area */}
-        <div className="flex flex-1 min-h-0">
-          {/* Sidebar */}
-          <MonitorPresetsSidebar />
-          {/* Canvas */}
-          <EditorCanvas />
-        </div>
-
-        {/* Preview & Export */}
-        <PreviewPanel />
-      </div>
+      <AppContent />
     </StoreProvider>
   )
 }

--- a/src/components/InfoDialog.tsx
+++ b/src/components/InfoDialog.tsx
@@ -1,0 +1,141 @@
+interface InfoDialogProps {
+  onClose: () => void
+}
+
+export default function InfoDialog({ onClose }: InfoDialogProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Dialog */}
+      <div className="relative bg-gray-900 border border-gray-700 rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[85vh] overflow-y-auto">
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-500 hover:text-gray-300 transition-colors z-10"
+        >
+          <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+          </svg>
+        </button>
+
+        <div className="p-6 space-y-5">
+          {/* Title */}
+          <div>
+            <h2 className="text-lg font-semibold text-gray-100">
+              How Windows Span Mode Works
+            </h2>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Understanding how Spanwright generates your wallpaper
+            </p>
+          </div>
+
+          {/* Step 1 */}
+          <section className="space-y-2">
+            <div className="flex items-start gap-3">
+              <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">1</span>
+              <div>
+                <h3 className="text-sm font-medium text-gray-200">One wide image, stretched across all screens</h3>
+                <p className="text-xs text-gray-400 mt-1 leading-relaxed">
+                  Spanwright generates a single wide image that Windows will stretch across all your monitors using <strong className="text-gray-300">Span</strong> mode. Each monitor gets a slice of this image.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Step 2 */}
+          <section className="space-y-2">
+            <div className="flex items-start gap-3">
+              <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">2</span>
+              <div>
+                <h3 className="text-sm font-medium text-gray-200">Windows uses its own display arrangement</h3>
+                <p className="text-xs text-gray-400 mt-1 leading-relaxed">
+                  Windows paints this image based on how your monitors are arranged in <strong className="text-gray-300">Settings &gt; Display</strong>, starting from the top-left corner. The left-to-right order and vertical offsets in Windows determine which slice each monitor gets.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Illustration placeholder */}
+          <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+            <div className="flex items-center justify-center gap-6">
+              {/* Physical layout illustration */}
+              <div className="text-center">
+                <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Your desk</div>
+                <div className="relative w-32 h-16">
+                  <div className="absolute left-0 bottom-0 w-12 h-9 border border-cyan-500/60 bg-cyan-500/10 rounded-sm flex items-center justify-center">
+                    <span className="text-[8px] text-cyan-400">Laptop</span>
+                  </div>
+                  <div className="absolute right-0 top-0 w-20 h-14 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center">
+                    <span className="text-[8px] text-blue-400">Monitor</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="text-gray-600 text-lg">&rarr;</div>
+
+              {/* Windows arrangement illustration */}
+              <div className="text-center">
+                <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Windows sees</div>
+                <div className="relative w-32 h-14">
+                  <div className="absolute left-0 top-0 w-10 h-8 border border-cyan-500/60 bg-cyan-500/10 rounded-sm flex items-center justify-center">
+                    <span className="text-[8px] text-cyan-400">1</span>
+                  </div>
+                  <div className="absolute right-0 top-0 w-18 h-12 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center" style={{ width: '72px', height: '48px', right: '0' }}>
+                    <span className="text-[8px] text-blue-400">2</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Step 3 */}
+          <section className="space-y-2">
+            <div className="flex items-start gap-3">
+              <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">3</span>
+              <div>
+                <h3 className="text-sm font-medium text-gray-200">Two layouts, one wallpaper</h3>
+                <p className="text-xs text-gray-400 mt-1 leading-relaxed">
+                  The <strong className="text-gray-300">Physical Layout</strong> tab controls what part of your image each monitor shows — based on real-world size and position on your desk. The <strong className="text-gray-300">Windows Arrangement</strong> tab controls how the output image is stitched together — matching how Windows will paint it.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* Step 4 */}
+          <section className="space-y-2">
+            <div className="flex items-start gap-3">
+              <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
+              <div>
+                <h3 className="text-sm font-medium text-gray-200">You don't need to change Windows settings</h3>
+                <p className="text-xs text-gray-400 mt-1 leading-relaxed">
+                  Just tell Spanwright how your monitors are currently arranged in Windows. If your Windows arrangement roughly matches your physical layout with monitors top-aligned, you can skip this step entirely — the default "auto-aligned" option handles it.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          {/* How to check */}
+          <div className="bg-gray-800/30 border border-gray-700/50 rounded-lg p-3 space-y-1.5">
+            <div className="text-xs font-medium text-gray-300">How to check your Windows arrangement:</div>
+            <ol className="text-xs text-gray-400 space-y-1 list-decimal list-inside">
+              <li>Open <strong className="text-gray-300">Settings &gt; System &gt; Display</strong></li>
+              <li>Look at the monitor rectangles at the top of the page</li>
+              <li>Note their left-to-right order and vertical positions</li>
+              <li>Replicate that layout in the Windows Arrangement tab</li>
+            </ol>
+          </div>
+
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium py-2 rounded-lg transition-colors"
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -26,7 +26,7 @@ export default function PreviewPanel() {
     }
 
     debounceRef.current = requestAnimationFrame(() => {
-      const result = generateOutput(state.monitors, state.sourceImage)
+      const result = generateOutput(state.monitors, state.sourceImage, state.windowsArrangement)
       setOutput(result)
       setIsGenerating(false)
     })
@@ -36,7 +36,7 @@ export default function PreviewPanel() {
         cancelAnimationFrame(debounceRef.current)
       }
     }
-  }, [state.monitors, state.sourceImage])
+  }, [state.monitors, state.sourceImage, state.windowsArrangement])
 
   // Draw preview
   useEffect(() => {
@@ -45,10 +45,11 @@ export default function PreviewPanel() {
     if (!canvas || !container || !output) return
 
     const ctx = canvas.getContext('2d')!
-    const containerWidth = container.clientWidth - 32
+    const containerWidth = container.clientWidth - 64
+    const containerHeight = container.clientHeight - 32
 
     // Scale to fit container
-    const displayScale = Math.min(1, containerWidth / output.width, 200 / output.height)
+    const displayScale = Math.min(1, containerWidth / output.width, containerHeight / output.height)
     canvas.width = Math.round(output.width * displayScale)
     canvas.height = Math.round(output.height * displayScale)
 
@@ -89,7 +90,7 @@ export default function PreviewPanel() {
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `wallpaper-${output.width}x${output.height}.${format}`
+      a.download = `spanwright-${output.width}x${output.height}.${format}`
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)
@@ -99,7 +100,7 @@ export default function PreviewPanel() {
 
   if (state.monitors.length === 0) {
     return (
-      <div className="bg-gray-900 border-t border-gray-800 p-4 shrink-0">
+      <div className="flex items-center justify-center h-full">
         <div className="text-center text-gray-600 text-sm py-2">
           Add monitors and upload an image to see the output preview
         </div>
@@ -108,9 +109,9 @@ export default function PreviewPanel() {
   }
 
   return (
-    <div className="bg-gray-900 border-t border-gray-800 shrink-0">
+    <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-800">
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-800 bg-gray-900 shrink-0">
         <div className="flex items-center gap-3">
           <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
             Output Preview
@@ -168,13 +169,22 @@ export default function PreviewPanel() {
       </div>
 
       {/* Preview canvas */}
-      <div ref={containerRef} className="p-4 flex justify-center overflow-x-auto">
+      <div ref={containerRef} className="flex-1 flex items-center justify-center p-8 overflow-auto">
         <canvas
           ref={canvasRef}
           className="border border-gray-800 rounded bg-black"
-          style={{ imageRendering: 'auto', maxHeight: '200px' }}
+          style={{ imageRendering: 'auto' }}
         />
       </div>
+
+      {/* Windows arrangement info */}
+      {state.useWindowsArrangement && (
+        <div className="px-4 py-2 border-t border-gray-800 bg-gray-900 shrink-0">
+          <div className="text-xs text-gray-500">
+            Output uses your custom Windows arrangement for monitor ordering and vertical offsets.
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -89,13 +89,6 @@ export default function Toolbar() {
 
       {/* Spacer */}
       <div className="flex-1" />
-
-      {/* Windows note */}
-      {hasMonitors && (
-        <div className="text-xs text-gray-600 max-w-xs text-right">
-          Ensure your Windows display arrangement matches this physical layout.
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/WindowsArrangementCanvas.tsx
+++ b/src/components/WindowsArrangementCanvas.tsx
@@ -1,0 +1,381 @@
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react'
+import { useStore } from '../store'
+import type { Monitor } from '../types'
+import InfoDialog from './InfoDialog'
+
+const MONITOR_COLORS = [
+  '#3b82f6', '#8b5cf6', '#06b6d4', '#10b981',
+  '#f59e0b', '#ef4444', '#ec4899', '#6366f1',
+]
+
+export default function WindowsArrangementCanvas() {
+  const { state, dispatch } = useStore()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [dimensions, setDimensions] = useState({ width: 800, height: 500 })
+  const [dragging, setDragging] = useState<string | null>(null)
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
+  const [showInfoDialog, setShowInfoDialog] = useState(false)
+
+  // Resize observer
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setDimensions({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        })
+      }
+    })
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [])
+
+  // Build a map of monitor id -> Monitor for quick lookup
+  const monitorMap = useMemo(() => {
+    const map = new Map<string, Monitor>()
+    for (const m of state.monitors) map.set(m.id, m)
+    return map
+  }, [state.monitors])
+
+  // Compute display scale: fit all monitors within the canvas with padding
+  const { displayScale, offsetX, offsetY } = useMemo(() => {
+    if (state.windowsArrangement.length === 0) {
+      return { displayScale: 0.1, offsetX: 0, offsetY: 0 }
+    }
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const wp of state.windowsArrangement) {
+      const mon = monitorMap.get(wp.monitorId)
+      if (!mon) continue
+      minX = Math.min(minX, wp.pixelX)
+      minY = Math.min(minY, wp.pixelY)
+      maxX = Math.max(maxX, wp.pixelX + mon.preset.resolutionX)
+      maxY = Math.max(maxY, wp.pixelY + mon.preset.resolutionY)
+    }
+    const contentW = maxX - minX
+    const contentH = maxY - minY
+    if (contentW === 0 || contentH === 0) return { displayScale: 0.1, offsetX: 0, offsetY: 0 }
+
+    const pad = 80
+    const availW = dimensions.width - pad * 2
+    const availH = dimensions.height - pad * 2
+    const scale = Math.min(availW / contentW, availH / contentH, 0.3)
+    const ox = pad + (availW - contentW * scale) / 2 - minX * scale
+    const oy = pad + (availH - contentH * scale) / 2 - minY * scale
+    return { displayScale: scale, offsetX: ox, offsetY: oy }
+  }, [state.windowsArrangement, monitorMap, dimensions])
+
+  // Convert pixel position to display position
+  const toDisplayX = useCallback((px: number) => px * displayScale + offsetX, [displayScale, offsetX])
+  const toDisplayY = useCallback((px: number) => px * displayScale + offsetY, [displayScale, offsetY])
+  const toPixelX = useCallback((dx: number) => (dx - offsetX) / displayScale, [displayScale, offsetX])
+  const toPixelY = useCallback((dy: number) => (dy - offsetY) / displayScale, [displayScale, offsetY])
+
+  // Find monitor index in physical layout order for consistent coloring
+  const getMonitorIndex = useCallback((id: string) => {
+    return state.monitors.findIndex(m => m.id === id)
+  }, [state.monitors])
+
+  // Draw the canvas
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')!
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = dimensions.width * dpr
+    canvas.height = dimensions.height * dpr
+    ctx.scale(dpr, dpr)
+
+    // Background
+    ctx.fillStyle = '#0a0a1a'
+    ctx.fillRect(0, 0, dimensions.width, dimensions.height)
+
+    // Draw subtle grid
+    ctx.strokeStyle = '#1e293b'
+    ctx.lineWidth = 0.5
+    const gridStep = 100 * displayScale
+    if (gridStep > 3) {
+      const startX = offsetX % gridStep
+      for (let x = startX; x < dimensions.width; x += gridStep) {
+        ctx.beginPath()
+        ctx.moveTo(x, 0)
+        ctx.lineTo(x, dimensions.height)
+        ctx.stroke()
+      }
+      const startY = offsetY % gridStep
+      for (let y = startY; y < dimensions.height; y += gridStep) {
+        ctx.beginPath()
+        ctx.moveTo(0, y)
+        ctx.lineTo(dimensions.width, y)
+        ctx.stroke()
+      }
+    }
+
+    // Draw monitors
+    for (const wp of state.windowsArrangement) {
+      const mon = monitorMap.get(wp.monitorId)
+      if (!mon) continue
+      const idx = getMonitorIndex(wp.monitorId)
+      const color = MONITOR_COLORS[idx % MONITOR_COLORS.length]
+
+      const x = toDisplayX(wp.pixelX)
+      const y = toDisplayY(wp.pixelY)
+      const w = mon.preset.resolutionX * displayScale
+      const h = mon.preset.resolutionY * displayScale
+
+      // Fill
+      ctx.fillStyle = color
+      ctx.globalAlpha = 0.15
+      ctx.beginPath()
+      ctx.roundRect(x, y, w, h, 3)
+      ctx.fill()
+      ctx.globalAlpha = 1
+
+      // Border
+      ctx.strokeStyle = color
+      ctx.lineWidth = dragging === wp.monitorId ? 2.5 : 1.5
+      ctx.beginPath()
+      ctx.roundRect(x, y, w, h, 3)
+      ctx.stroke()
+
+      // Label
+      if (w > 50 && h > 30) {
+        const labelW = Math.min(w - 8, 200)
+        const showRes = w > 100 && h > 50
+        const labelH = showRes ? 40 : 24
+        ctx.fillStyle = 'rgba(0,0,0,0.75)'
+        ctx.beginPath()
+        ctx.roundRect(x + 4, y + 4, labelW, labelH, 3)
+        ctx.fill()
+
+        ctx.fillStyle = '#ffffff'
+        ctx.font = 'bold 11px system-ui, sans-serif'
+        ctx.textAlign = 'left'
+        ctx.fillText(mon.preset.name, x + 8, y + 17, labelW - 8)
+
+        if (showRes) {
+          ctx.fillStyle = '#94a3b8'
+          ctx.font = '9px system-ui, sans-serif'
+          ctx.fillText(`${mon.preset.resolutionX} x ${mon.preset.resolutionY} px`, x + 8, y + 31, labelW - 8)
+        }
+      }
+    }
+  }, [state.windowsArrangement, monitorMap, dimensions, displayScale, offsetX, offsetY, dragging, getMonitorIndex, toDisplayX, toDisplayY])
+
+  // Mouse handlers for dragging
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (!state.useWindowsArrangement) return
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+
+    // Find which monitor was clicked (reverse order for top-most first)
+    for (let i = state.windowsArrangement.length - 1; i >= 0; i--) {
+      const wp = state.windowsArrangement[i]
+      const mon = monitorMap.get(wp.monitorId)
+      if (!mon) continue
+      const x = toDisplayX(wp.pixelX)
+      const y = toDisplayY(wp.pixelY)
+      const w = mon.preset.resolutionX * displayScale
+      const h = mon.preset.resolutionY * displayScale
+
+      if (mx >= x && mx <= x + w && my >= y && my <= y + h) {
+        setDragging(wp.monitorId)
+        setDragOffset({ x: mx - x, y: my - y })
+        return
+      }
+    }
+  }, [state.windowsArrangement, state.useWindowsArrangement, monitorMap, displayScale, toDisplayX, toDisplayY])
+
+  // Compute total pixel dimensions of all monitors for drag clamping
+  const totalMonitorBounds = useMemo(() => {
+    let totalW = 0, totalH = 0
+    for (const m of state.monitors) {
+      totalW += m.preset.resolutionX
+      totalH = Math.max(totalH, m.preset.resolutionY)
+    }
+    return { totalW, totalH }
+  }, [state.monitors])
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!dragging) return
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+
+    let newPixelX = Math.round(toPixelX(mx - dragOffset.x))
+    let newPixelY = Math.round(toPixelY(my - dragOffset.y))
+
+    // Clamp: don't let any monitor drift beyond 2x the total arrangement width/height
+    // from the bounding box of the other monitors
+    const others = state.windowsArrangement.filter(wp => wp.monitorId !== dragging)
+    if (others.length > 0) {
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+      for (const wp of others) {
+        const mon = monitorMap.get(wp.monitorId)
+        if (!mon) continue
+        minX = Math.min(minX, wp.pixelX)
+        minY = Math.min(minY, wp.pixelY)
+        maxX = Math.max(maxX, wp.pixelX + mon.preset.resolutionX)
+        maxY = Math.max(maxY, wp.pixelY + mon.preset.resolutionY)
+      }
+      const limitW = totalMonitorBounds.totalW
+      const limitH = totalMonitorBounds.totalH
+      newPixelX = Math.max(minX - limitW, Math.min(maxX + limitW, newPixelX))
+      newPixelY = Math.max(minY - limitH, Math.min(maxY + limitH, newPixelY))
+    }
+
+    dispatch({ type: 'MOVE_WINDOWS_MONITOR', monitorId: dragging, pixelX: newPixelX, pixelY: newPixelY })
+  }, [dragging, dragOffset, toPixelX, toPixelY, dispatch, state.windowsArrangement, monitorMap, totalMonitorBounds])
+
+  const handleMouseUp = useCallback(() => {
+    setDragging(null)
+  }, [])
+
+  // Compute validation warnings
+  const warnings = useMemo(() => {
+    const warns: string[] = []
+    if (!state.useWindowsArrangement || state.monitors.length < 2) return warns
+
+    // Check if left-to-right order matches physical layout
+    const physicalOrder = [...state.monitors].sort((a, b) => a.physicalX - b.physicalX).map(m => m.id)
+    const windowsOrder = [...state.windowsArrangement].sort((a, b) => a.pixelX - b.pixelX).map(wp => wp.monitorId)
+
+    if (physicalOrder.join(',') !== windowsOrder.join(',')) {
+      warns.push('Your Windows display order doesn\'t match your physical layout. This is fine but make sure it\'s intentional.')
+    }
+
+    // Check for large vertical offset differences
+    const physicalSorted = [...state.monitors].sort((a, b) => a.physicalX - b.physicalX)
+    const windowsSorted = [...state.windowsArrangement].sort((a, b) => a.pixelX - b.pixelX)
+
+    for (let i = 0; i < Math.min(physicalSorted.length, windowsSorted.length); i++) {
+      const phys = physicalSorted[i]
+      const win = windowsSorted[i]
+      if (phys.id === win.monitorId) {
+        // Compare relative vertical positioning
+        const physMinY = Math.min(...physicalSorted.map(m => m.physicalY))
+        const winMinY = Math.min(...windowsSorted.map(wp => wp.pixelY))
+        const physRelY = phys.physicalY - physMinY
+        const winRelY = win.pixelY - winMinY
+        // Convert physical offset to approximate pixels for comparison
+        const physRelPx = physRelY * phys.ppi
+        if (Math.abs(physRelPx - winRelY) > 200) {
+          warns.push('Your Windows vertical alignment differs significantly from your physical layout. The wallpaper will match your Windows arrangement, which may not look physically seamless.')
+          break
+        }
+      }
+    }
+
+    return warns
+  }, [state.useWindowsArrangement, state.monitors, state.windowsArrangement])
+
+  if (state.monitors.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-600">
+        <div className="text-center">
+          <div className="text-lg font-medium mb-1">No monitors added</div>
+          <div className="text-sm">Add monitors in the Physical Layout tab first</div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Top bar */}
+      <div className="bg-gray-900 border-b border-gray-800 px-4 py-2.5 flex items-center gap-4 shrink-0 flex-wrap">
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={!state.useWindowsArrangement}
+            onChange={(e) => dispatch({ type: 'SET_USE_WINDOWS_ARRANGEMENT', value: !e.target.checked })}
+            className="accent-blue-500"
+          />
+          <span className="text-xs text-gray-300">
+            My Windows display arrangement matches my physical layout (top-aligned)
+          </span>
+        </label>
+
+        {state.useWindowsArrangement && (
+          <>
+            <div className="w-px h-5 bg-gray-700" />
+            <button
+              onClick={() => dispatch({ type: 'SYNC_WINDOWS_ARRANGEMENT' })}
+              className="text-xs bg-gray-800 hover:bg-gray-700 text-gray-300 px-2.5 py-1 rounded border border-gray-700 transition-colors"
+            >
+              Reset to default
+            </button>
+          </>
+        )}
+
+        <div className="flex-1" />
+
+        <button
+          onClick={() => setShowInfoDialog(true)}
+          className="text-xs text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-1"
+        >
+          <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+            <path fillRule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm6.5-.25A.75.75 0 017.25 7h1a.75.75 0 01.75.75v2.75h.25a.75.75 0 010 1.5h-2a.75.75 0 010-1.5h.25v-2h-.25a.75.75 0 01-.75-.75zM8 6a1 1 0 100-2 1 1 0 000 2z" />
+          </svg>
+          How does this work?
+        </button>
+      </div>
+
+      {/* Warnings */}
+      {warnings.length > 0 && (
+        <div className="px-4 py-2 space-y-1 bg-yellow-900/20 border-b border-yellow-700/30">
+          {warnings.map((w, i) => (
+            <div key={i} className="text-xs text-yellow-400 flex items-start gap-1.5">
+              <span className="shrink-0 mt-0.5">⚠</span>
+              <span>{w}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Canvas area */}
+      <div
+        ref={containerRef}
+        className="flex-1 relative overflow-hidden"
+        style={{ cursor: state.useWindowsArrangement ? (dragging ? 'grabbing' : 'default') : 'default' }}
+      >
+        <canvas
+          ref={canvasRef}
+          style={{ width: dimensions.width, height: dimensions.height }}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={handleMouseUp}
+        />
+
+        {/* Disabled overlay when checkbox is on */}
+        {!state.useWindowsArrangement && (
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-950/50">
+            <div className="bg-gray-900/90 backdrop-blur rounded-lg px-6 py-4 text-center max-w-md">
+              <div className="text-sm text-gray-300 font-medium mb-1">Auto-aligned mode</div>
+              <div className="text-xs text-gray-500">
+                Monitors will be arranged top-aligned in the same left-to-right order as your physical layout.
+                Uncheck the box above to customize.
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Help text when enabled */}
+        {state.useWindowsArrangement && !dragging && (
+          <div className="absolute bottom-3 right-3 bg-gray-900/60 backdrop-blur px-2 py-1 rounded text-[10px] text-gray-500 select-none">
+            Drag monitors to match your Windows Display Settings arrangement
+          </div>
+        )}
+      </div>
+
+      {/* Info dialog */}
+      {showInfoDialog && <InfoDialog onClose={() => setShowInfoDialog(false)} />}
+    </div>
+  )
+}

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -20,8 +20,8 @@ export const MONITOR_PRESETS: MonitorPreset[] = [
   { name: '32" 4K', diagonal: 32, aspectRatio: [16, 9], resolutionX: 3840, resolutionY: 2160 },
 
   // Ultrawides
-  { name: '34" Ultrawide QHD', diagonal: 34, aspectRatio: [21, 9], resolutionX: 3440, resolutionY: 1440 },
   { name: '34" Ultrawide WFHD', diagonal: 34, aspectRatio: [21, 9], resolutionX: 2560, resolutionY: 1080 },
+  { name: '34" Ultrawide QHD', diagonal: 34, aspectRatio: [21, 9], resolutionX: 3440, resolutionY: 1440 },
   { name: '38" Ultrawide QHD+', diagonal: 38, aspectRatio: [21, 9], resolutionX: 3840, resolutionY: 1600 },
 
   // Super Ultrawides

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,14 @@ export interface SourceImage {
   physicalHeight: number
 }
 
+export interface WindowsMonitorPosition {
+  monitorId: string       // Links to the Monitor in the physical layout
+  pixelX: number          // X position in Windows arrangement (pixels)
+  pixelY: number          // Y position in Windows arrangement (pixels)
+}
+
+export type ActiveTab = 'physical' | 'windows' | 'preview'
+
 export interface AppState {
   monitors: Monitor[]
   sourceImage: SourceImage | null
@@ -37,4 +45,8 @@ export interface AppState {
   canvasOffsetX: number   // pan offset
   canvasOffsetY: number
   unit: 'inches' | 'cm'
+  // Windows arrangement
+  windowsArrangement: WindowsMonitorPosition[]
+  useWindowsArrangement: boolean  // false = assume top-aligned, same order as physical
+  activeTab: ActiveTab
 }


### PR DESCRIPTION
## Summary

### Windows Display Alignment Integration
- Added three-tab layout: **Physical Layout**, **Windows Arrangement**, and **Preview & Export**
- New **Windows Arrangement** canvas where users can replicate their Windows Display Settings layout (pixel-scaled, vertically draggable monitors)
- "Auto-aligned" checkbox (default ON) to skip manual Windows arrangement when physical and Windows layouts match
- Instructional **info dialog** explaining Windows span mode and why both layouts matter
- Output generation now uses Windows arrangement for pixel offsets and physical layout for image cropping
- Validation warnings when Windows order differs from physical order or vertical offsets diverge significantly
- Drag clamping on the Windows Arrangement canvas to prevent monitors from being placed too far apart (bounded to 2x total arrangement size)

### Collapsible Sidebar (Floating)
- Sidebar is now **absolutely positioned** (floating over the canvas), so opening/closing it never causes the grid to resize, flash, or shift
- When collapsed, a small **"Add a Monitor"** button floats in the top-left corner of the canvas
- When expanded, the sidebar overlays the left side of the canvas with a shadow

### Monitor Placement & Drag-and-Drop Improvements
- **Drop centering**: Dragged monitors are now placed centered on the cursor (not top-left aligned), matching the ghost position
- **Click-to-add centering**: Button-click additions now place the monitor at the center of the visible canvas area
- **Drag ghost sizing**: Capped drag image to 500px max dimension to fix ultrawide ghosts not rendering in some browsers; enforced minimum 20px so tiny monitors remain visible
- **Ultrawide preset ordering**: WFHD now listed before QHD in the Ultrawides section

### Arrow Key Nudging
- Selected monitors can now be nudged with arrow keys (like PowerPoint):
  - **Arrow keys**: 1 inch per press
  - **Shift + Arrow**: 0.1 inch (fine adjustment)
  - **Ctrl + Arrow**: 5 inches (large jump)
- Respects snap-to-grid when enabled

### Zoom Limits
- Minimum canvas scale raised to **5 px/in** (from 2) so monitors never become invisibly small when zooming out

### Layout & UX Polish
- **Toolbar moved below tabs**: Upload Image / Inches / Snap bar now renders inside the Physical Layout tab, so switching tabs doesn't cause layout bounce
- Sidebar title restructured: **"Add a Monitor"** as the main heading, **"Monitor Presets"** as a sub-heading below it