### PR TITLE
Added Windows Display Settings-like snapping to arrangment grid, added Troubleshooting Guide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import EditorCanvas from './components/EditorCanvas'
 import Toolbar from './components/Toolbar'
 import PreviewPanel from './components/PreviewPanel'
 import WindowsArrangementCanvas from './components/WindowsArrangementCanvas'
+import TroubleshootingGuide from './components/TroubleshootingGuide'
 import type { ActiveTab } from './types'
 
 function TabButton({ tab, label, active, onClick }: { tab: ActiveTab; label: string; active: boolean; onClick: (tab: ActiveTab) => void }) {
@@ -40,9 +41,19 @@ function AppContent() {
             Spanwright
           </h1>
         </div>
-        <span className="text-xs text-gray-500">
+        <span className="text-xs text-gray-500 flex-1">
           Multi-Monitor Wallpaper Alignment Tool
         </span>
+        <button
+          onClick={() => dispatch({ type: 'SET_SHOW_TROUBLESHOOTING_GUIDE', value: true })}
+          className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
+          title="Troubleshooting Guide"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-xs">Troubleshooting</span>
+        </button>
       </header>
 
       {/* Tabs */}
@@ -73,6 +84,11 @@ function AppContent() {
         <div className="flex-1 min-h-0 overflow-auto">
           <PreviewPanel />
         </div>
+      )}
+
+      {/* Troubleshooting Guide Modal */}
+      {state.showTroubleshootingGuide && (
+        <TroubleshootingGuide onClose={() => dispatch({ type: 'SET_SHOW_TROUBLESHOOTING_GUIDE', value: false })} />
       )}
     </div>
   )

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -2,8 +2,9 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { useStore } from '../store'
 import { generateOutput, type OutputResult } from '../generateOutput'
 
+
 export default function PreviewPanel() {
-  const { state } = useStore()
+  const { state, dispatch } = useStore()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [output, setOutput] = useState<OutputResult | null>(null)
@@ -167,6 +168,18 @@ export default function PreviewPanel() {
           </div>
         )}
       </div>
+
+      {/* Troubleshooting link */}
+      {output && (
+        <div className="flex items-center justify-end px-4 py-1.5 border-b border-gray-800 bg-gray-900/60 shrink-0">
+          <button
+            onClick={() => dispatch({ type: 'SET_SHOW_TROUBLESHOOTING_GUIDE', value: true })}
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors underline underline-offset-2 decoration-gray-600 hover:decoration-gray-400"
+          >
+            Wallpaper not looking right? See the Troubleshooting Guide
+          </button>
+        </div>
+      )}
 
       {/* Preview canvas */}
       <div ref={containerRef} className="flex-1 flex items-center justify-center p-8 overflow-auto">

--- a/src/components/TroubleshootingGuide.tsx
+++ b/src/components/TroubleshootingGuide.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+
+interface TroubleshootingGuideProps {
+  onClose: () => void
+}
+
+function AccordionSection({ title, children, defaultOpen = false }: { title: string; children: React.ReactNode; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <div className="border border-gray-700/60 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-gray-800/40 hover:bg-gray-800/70 transition-colors text-left"
+      >
+        <span className="text-sm font-medium text-gray-200">{title}</span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-200 shrink-0 ml-3 ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="px-4 py-3 border-t border-gray-700/40 space-y-3">
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function TroubleshootingGuide({ onClose }: TroubleshootingGuideProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto">
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Content */}
+      <div className="relative bg-gray-900 border border-gray-700 rounded-xl shadow-2xl max-w-2xl w-full mx-4 my-8">
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-300 transition-colors z-10"
+        >
+          <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+          </svg>
+        </button>
+
+        <div className="p-6 sm:p-8 space-y-6">
+          {/* Hero / Intro */}
+          <div>
+            <h2 className="text-xl font-bold text-gray-100">
+              Troubleshooting Guide
+            </h2>
+            <p className="text-sm text-gray-400 mt-1">
+              Getting your wallpaper to display perfectly across all your monitors.
+            </p>
+          </div>
+
+          {/* Priority Tip Callout */}
+          <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 space-y-2">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-blue-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <h3 className="text-sm font-semibold text-blue-300">
+                If Span isn't working, try Tile
+              </h3>
+            </div>
+            <p className="text-sm text-gray-300 leading-relaxed">
+              Your wallpaper is designed for Windows <strong className="text-blue-300">Span</strong> mode, and that should work perfectly in most setups. But if you're seeing stretching, bleed, or misalignment, try switching to <strong className="text-blue-300">Tile</strong> instead: right-click your desktop &gt; Personalize &gt; Background, and change the fit mode.
+            </p>
+            <p className="text-xs text-gray-400 leading-relaxed">
+              <strong className="text-gray-300">Why does this help?</strong> Span mode scales your image to fit the Windows virtual desktop bounding box. If any monitor is even a few pixels offset in your display arrangement, Windows will stretch the image to compensate, causing visible bleed. Tile mode places the image at exact 1:1 pixel scale with no resizing, bypassing the issue entirely.
+            </p>
+          </div>
+
+          {/* Accordion Sections */}
+          <div className="space-y-2">
+
+            {/* Section: Virtual Desktop Misalignment */}
+            <AccordionSection title="I see a few pixels of overflow/bleed between monitors">
+              <p className="text-sm text-gray-300 leading-relaxed">
+                This usually means your Windows display arrangement has a small vertical offset. Even a few pixels will cause Windows to scale your wallpaper.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                To check, open PowerShell and run:
+              </p>
+              <div className="bg-gray-950 border border-gray-700 rounded-md p-3 font-mono text-xs text-gray-300 overflow-x-auto">
+                <div>Add-Type -AssemblyName System.Windows.Forms</div>
+                <div>[System.Windows.Forms.SystemInformation]::VirtualScreen</div>
+              </div>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Look at the <strong className="text-gray-100">Y</strong> and <strong className="text-gray-100">Height</strong> values. If Y is anything other than 0, or Height is larger than your tallest monitor's vertical resolution, one of your monitors is offset.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display. Carefully drag your monitors so they're perfectly aligned. The snap behavior can sometimes leave a few pixels of offset — zoom in and adjust carefully. Then re-run the PowerShell command to verify.
+              </p>
+              <p className="text-xs text-gray-400 leading-relaxed">
+                If you'd rather not adjust your display arrangement (since it affects cursor movement between screens), just use <strong className="text-gray-300">Tile</strong> mode instead of Span, which bypasses this issue entirely.
+              </p>
+            </AccordionSection>
+
+            {/* Section: Display Scaling */}
+            <AccordionSection title="My wallpaper looks slightly zoomed in or shifted">
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Check that all your monitors are set to <strong className="text-gray-100">100% scaling</strong>. Open Settings &gt; System &gt; Display, click on each monitor individually, and verify the Scale setting.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                If you need to run a monitor at higher than 100% scaling (common on high-DPI laptops), be aware that Windows may factor this into the span calculation differently. In this case, <strong className="text-gray-100">Tile mode is strongly recommended</strong> over Span.
+              </p>
+            </AccordionSection>
+
+            {/* Section: Verifying Output */}
+            <AccordionSection title="How do I verify my wallpaper dimensions are correct?">
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Right-click your downloaded wallpaper file &gt; Properties &gt; Details tab. Check the <strong className="text-gray-100">Width</strong> and <strong className="text-gray-100">Height</strong> values.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Your image width should equal the sum of all your monitors' horizontal resolutions. For example: 1920 + 1920 + 2560 = 6400px wide.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Your image height should equal the tallest monitor's vertical resolution (plus any vertical offset if your monitors aren't top-aligned in the Windows arrangement).
+              </p>
+              <p className="text-xs text-gray-400 leading-relaxed">
+                If these numbers don't match, go back to Spanwright and verify your monitor resolutions are entered correctly.
+              </p>
+            </AccordionSection>
+
+            {/* Section: Diagnostic Test */}
+            <AccordionSection title="I want to test if my setup is aligned correctly">
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Try creating a simple test wallpaper to diagnose alignment issues:
+              </p>
+              <ol className="text-sm text-gray-300 leading-relaxed list-decimal list-inside space-y-1.5 ml-1">
+                <li>In Spanwright, set up your monitor layout as usual.</li>
+                <li>Use a test image with a grid pattern or clearly marked regions — or just use a solid color with distinct colored blocks where each monitor boundary should be.</li>
+                <li>Apply the wallpaper using <strong className="text-gray-100">Tile</strong> mode.</li>
+                <li>Check each monitor: do the boundaries line up exactly at the screen edges? If you see part of the next monitor's section bleeding over, your Windows display arrangement may have a small offset (see the "Virtual Desktop Misalignment" section above).</li>
+              </ol>
+            </AccordionSection>
+
+            {/* Section: Monitor Order Mismatch */}
+            <AccordionSection title="The wallpaper sections appear on the wrong monitors">
+              <p className="text-sm text-gray-300 leading-relaxed">
+                Spanwright stitches the wallpaper left-to-right based on the physical layout you've built. Windows applies it left-to-right based on your display arrangement in Settings &gt; Display.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                If these orders don't match, the wallpaper sections will appear on the wrong screens.
+              </p>
+              <p className="text-sm text-gray-300 leading-relaxed">
+                <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display and make sure your monitors are arranged in the same left-to-right order as your Spanwright layout. You can drag monitors to reorder them. Click <strong className="text-gray-100">"Identify"</strong> to see which number corresponds to which physical screen.
+              </p>
+            </AccordionSection>
+
+          </div>
+
+          {/* Footer */}
+          <button
+            onClick={onClose}
+            className="w-full bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm font-medium py-2.5 rounded-lg transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -16,6 +16,7 @@ interface State {
   windowsArrangement: WindowsMonitorPosition[]
   useWindowsArrangement: boolean
   activeTab: ActiveTab
+  showTroubleshootingGuide: boolean
 }
 
 type Action =
@@ -39,6 +40,7 @@ type Action =
   | { type: 'SET_USE_WINDOWS_ARRANGEMENT'; value: boolean }
   | { type: 'MOVE_WINDOWS_MONITOR'; monitorId: string; pixelX: number; pixelY: number }
   | { type: 'SYNC_WINDOWS_ARRANGEMENT' }
+  | { type: 'SET_SHOW_TROUBLESHOOTING_GUIDE'; value: boolean }
 
 const initialState: State = {
   monitors: [],
@@ -53,6 +55,7 @@ const initialState: State = {
   windowsArrangement: [],
   useWindowsArrangement: false,
   activeTab: 'physical',
+  showTroubleshootingGuide: false,
 }
 
 /**
@@ -175,6 +178,8 @@ function reducer(state: State, action: Action): State {
         ...state,
         windowsArrangement: generateDefaultWindowsArrangement(state.monitors),
       }
+    case 'SET_SHOW_TROUBLESHOOTING_GUIDE':
+      return { ...state, showTroubleshootingGuide: action.value }
     default:
       return state
   }


### PR DESCRIPTION
## Summary

### Troubleshooting Guide
- Added a new full-screen modal (`TroubleshootingGuide.tsx`) with a clean, dark-themed layout containing collapsible accordion sections for common multi-monitor wallpaper issues: virtual desktop misalignment, display scaling, verifying output dimensions, diagnostic testing, and monitor order mismatch.
- A highlighted callout at the top explains when to try Tile mode as a fallback if Span isn't working correctly.
- Added a "Troubleshooting" button with a help icon in the main app header to open the guide from anywhere.
- Added a subtle "Wallpaper not looking right?" link in the Preview & Export panel that also opens the guide.
- Wired up via a `showTroubleshootingGuide` flag in the global store.

### Windows Arrangement — Grid Snapping & Drag Stability
- **Frozen scale during drag**: The auto-fit zoom/pan is now locked when a drag begins, preventing the canvas from jittering as the bounding box changes mid-drag. Scale recalculates smoothly on mouse-up.
- **Edge snapping**: All four edges of the dragged monitor snap to all four edges of every other monitor within a 30-screen-pixel threshold — giving a Windows Display Settings-style "sticky" feel for both adjacency (side-by-side) and alignment (tops/bottoms lining up).
- **Overlap prevention**: After snapping, positions are checked for overlap and pushed to the nearest non-overlapping edge, with iteration to handle cascading cases.
- **Warning overlay fix**: The yellow validation warnings are now absolutely positioned over the canvas instead of in document flow, so they no longer cause layout jitter when they toggle on/off during drag.