### PR TITLE
Add rotation, increase zoom, add custom monitor limits

### DIFF
--- a/src/components/ConfigManager.tsx
+++ b/src/components/ConfigManager.tsx
@@ -64,6 +64,7 @@ export default function ConfigManager() {
         preset: m.preset,
         physicalX: m.physicalX,
         physicalY: m.physicalY,
+        rotation: m.rotation,
       })),
     }
     const updated = [newConfig, ...configs].slice(0, MAX_CONFIGS)
@@ -78,7 +79,7 @@ export default function ConfigManager() {
     dispatch({ type: 'CLEAR_ALL_MONITORS' })
     // Add each monitor from the saved config
     for (const m of config.monitors) {
-      dispatch({ type: 'ADD_MONITOR', preset: m.preset, x: m.physicalX, y: m.physicalY })
+      dispatch({ type: 'ADD_MONITOR', preset: m.preset, x: m.physicalX, y: m.physicalY, rotation: m.rotation ?? 0 })
     }
     setOpen(false)
   }

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -12,8 +12,9 @@ export default function ImageUpload() {
       const img = new Image()
       img.onload = () => {
         const imgAspect = img.naturalWidth / img.naturalHeight
-        const physWidth = 72 // 6 feet
-        const physHeight = physWidth / imgAspect
+        const sixFeet = 72 // inches
+        const physWidth = img.naturalHeight > img.naturalWidth ? sixFeet * imgAspect : sixFeet
+        const physHeight = img.naturalHeight > img.naturalWidth ? sixFeet : sixFeet / imgAspect
 
         // Center on current viewport
         const containerEl = document.querySelector('[data-editor-canvas]')

--- a/src/generateOutput.ts
+++ b/src/generateOutput.ts
@@ -45,15 +45,18 @@ export function generateOutput(
   // Calculate vertical offsets relative to the topmost monitor
   const minWinY = Math.min(...sortedWinPos.map(wp => wp.pixelY))
 
+  const stripWidth = (mon: Monitor) => (mon.rotation ?? 0) === 90 ? mon.preset.resolutionY : mon.preset.resolutionX
+  const stripHeight = (mon: Monitor) => (mon.rotation ?? 0) === 90 ? mon.preset.resolutionX : mon.preset.resolutionY
+
   // Calculate total output dimensions
   const totalWidth = sortedWinPos.reduce((sum, wp) => {
     const mon = monitorMap.get(wp.monitorId)!
-    return sum + mon.preset.resolutionX
+    return sum + stripWidth(mon)
   }, 0)
 
   const maxHeight = Math.max(...sortedWinPos.map(wp => {
     const mon = monitorMap.get(wp.monitorId)!
-    return (wp.pixelY - minWinY) + mon.preset.resolutionY
+    return (wp.pixelY - minWinY) + stripHeight(mon)
   }))
 
   // Create output canvas
@@ -71,8 +74,8 @@ export function generateOutput(
 
   for (const wp of sortedWinPos) {
     const monitor = monitorMap.get(wp.monitorId)!
-    const stripWidth = monitor.preset.resolutionX
-    const stripHeight = monitor.preset.resolutionY
+    const sw = stripWidth(monitor)
+    const sh = stripHeight(monitor)
 
     // Vertical offset from Windows arrangement
     const yPixelOffset = Math.round(wp.pixelY - minWinY)
@@ -108,8 +111,8 @@ export function generateOutput(
         const srcH = (intBottom - intTop) * imgScaleY
 
         // Calculate destination pixel coordinates within the monitor strip
-        const monScaleX = stripWidth / monitor.physicalWidth
-        const monScaleY = stripHeight / monitor.physicalHeight
+        const monScaleX = sw / monitor.physicalWidth
+        const monScaleY = sh / monitor.physicalHeight
 
         const dstX = (intLeft - monLeft) * monScaleX
         const dstY = (intTop - monTop) * monScaleY
@@ -124,8 +127,8 @@ export function generateOutput(
       }
     }
 
-    monitorStrips.push({ monitor, stripWidth, stripHeight })
-    xOffset += stripWidth
+    monitorStrips.push({ monitor, stripWidth: sw, stripHeight: sh })
+    xOffset += sw
   }
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface Monitor {
   physicalHeight: number
   // PPI
   ppi: number
+  /** 0 = landscape, 90 = portrait (rotated 90° CW). Omitted on older saved configs. */
+  rotation?: 0 | 90
 }
 
 export interface SourceImage {
@@ -47,6 +49,7 @@ export interface SavedConfig {
     preset: MonitorPreset
     physicalX: number
     physicalY: number
+    rotation?: 0 | 90
   }[]
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,11 +21,19 @@ export function calculatePhysicalDimensions(resX: number, resY: number, ppi: num
 
 /**
  * Create a Monitor from a preset and position.
+ * rotation 90 = portrait (dimensions swapped).
  */
-export function createMonitor(preset: MonitorPreset, physicalX: number, physicalY: number): Monitor {
+export function createMonitor(
+  preset: MonitorPreset,
+  physicalX: number,
+  physicalY: number,
+  rotation: 0 | 90 = 0,
+): Monitor {
   const ppi = calculatePPI(preset.resolutionX, preset.resolutionY, preset.diagonal)
-  const { width, height } = calculatePhysicalDimensions(preset.resolutionX, preset.resolutionY, ppi)
-
+  let { width, height } = calculatePhysicalDimensions(preset.resolutionX, preset.resolutionY, ppi)
+  if (rotation === 90) {
+    ;[width, height] = [height, width]
+  }
   return {
     id: uuidv4(),
     preset,
@@ -34,6 +42,7 @@ export function createMonitor(preset: MonitorPreset, physicalX: number, physical
     physicalWidth: width,
     physicalHeight: height,
     ppi,
+    rotation,
   }
 }
 


### PR DESCRIPTION
## PR Summary

### Vertical images
- When pasting or uploading an image with **height > width**, default size is now **6 ft tall (72")** with width derived from aspect ratio, instead of 6 ft wide.

### Canvas zoom
- Canvas zoom cap increased from 200% to **250%**. Zoom-in and fit-view respect the new max.

### Monitor rotation
- **90° rotate control (↻)** added in the bottom-right of each monitor tile on the canvas. One click toggles portrait/landscape.
- Rotated monitors use **swapped resolution** (e.g. 1080×1920 when rotated from 1920×1080). `Monitor` type includes optional `rotation: 0 | 90`.
- Rotation is persisted in saved configs and applied in strip dimensions, hit-testing, snap, overlap, and labels across the app (editor, Windows Arrangement, and output generation).

### Drop placement
- Monitor preset **drop position** fixed: placement now uses the same clamped canvas offset as rendering, so the monitor **drops under the cursor** instead of offset (e.g. ~30" left).

### Windows Arrangement
- Rotated monitors are shown in **portrait** on the Windows Arrangement page, with correct strip width/height used for layout and interactions.

### Custom monitor limits and validation
- **Diagonal:** Custom monitor diagonal is limited to **5"–120"**. No silent capping: values outside this range are rejected with a warning.
- **Aspect ratio:** Custom resolution is limited to **aspect ratio ≤ 10:1** (no ultra-thin “line” monitors). Exceeding this shows a warning and blocks adding the monitor.
- **UI:** In the Custom Monitor section, validation **warnings** are shown in an amber box above Add/Cancel when limits are exceeded. The **Add** button is **disabled** until issues are fixed. Diagonal input has no `min`/`max` so users can type out-of-range values and see the warning instead of browser clamping.