### PR TITLE
Updating copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,50 +12,14 @@ Spanwright operates in **physical space** (inches/cm), so you arrange monitors a
 
 - **Physical-space monitor layout** — Arrange monitors on a canvas using real-world dimensions (calculated from diagonal size + resolution). A 27" monitor appears physically larger than a 15.6" laptop, exactly as on your desk.
 - **Drag-and-drop presets** — Choose from 18+ built-in monitor presets (laptops, standard monitors, ultrawides, super ultrawides) and drag them directly onto the canvas.
-- **Custom monitors** — Define any monitor by diagonal size, aspect ratio, and resolution. Supports fully custom resolution entry or filtered presets by aspect ratio.
-- **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display.
+- **Custom monitors** — Define any monitor by diagonal size, aspect ratio, and resolution. Supports fully custom resolution entry or filtered presets by aspect ratio. Diagonal is limited to 5"–120"; aspect ratio is limited to 10:1 or less (no ultra-thin “line” monitors). Validation warnings appear when limits are exceeded; Add is disabled until fixed.
+- **Monitor rotation** — Rotate any monitor 90° (portrait/landscape) via the ↻ button on each monitor tile. Resolution is swapped (e.g. 1080×1920 when rotated); rotation is saved in configs and reflected in output and the Windows Arrangement view.
+- **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display. Vertical images (height > width) default to 6 ft tall; horizontal ones default to 6 ft wide.
 - **Smart image recommendations** — Calculates the minimum source image resolution needed based on your layout's physical size and the highest-PPI monitor.
 - **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches the results side-by-side. Handles vertical offsets and fills empty space with black.
 - **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
-- **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom, right-click drag to pan. Custom scrollbars, snap-to-grid, and fit-to-view.
-- **Unit toggle** — Switch between inches and centimeters.
-
-## Getting Started
-
-### Prerequisites
-
-- [Node.js](https://nodejs.org/) 18+ (LTS recommended)
-- npm, yarn, or pnpm
-
-### Installation
-
-```bash
-git clone https://github.com/your-username/spanwright.git
-cd spanwright
-npm install
-```
-
-### Development
-
-```bash
-npm run dev
-```
-
-Opens at [http://localhost:5173](http://localhost:5173) by default.
-
-### Build for Production
-
-```bash
-npm run build
-```
-
-Output is in the `dist/` folder, ready for static hosting (e.g., Vercel, Netlify, GitHub Pages).
-
-### Preview Production Build
-
-```bash
-npm run preview
-```
+- **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom (up to 250%), right-click drag to pan. Custom scrollbars, snap-to-grid, and fit-to-view.
+- **Custom configs** — Save and load monitor layouts (names, positions, rotation, Windows arrangement). Configs are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Basic but very useful for multi-setup workflows.
 
 ## How to Use
 
@@ -65,7 +29,7 @@ Use the sidebar on the left to add monitors to the canvas:
 
 - **Click** a preset to add it at a default position
 - **Drag** a preset directly onto the canvas to place it where you want
-- **Custom monitors**: Click "+ Custom Monitor" to define a monitor by diagonal size, aspect ratio, and resolution
+- **Custom monitors**: Click "+ Custom Monitor" to define a monitor by diagonal size, aspect ratio, and resolution (diagonal 5"–120", aspect ratio ≤ 10:1)
 
 ### 2. Arrange Your Layout
 
@@ -74,8 +38,10 @@ Drag monitors on the canvas to match your physical desk arrangement:
 - Position your laptop screen lower-left, your main monitor centered, etc.
 - The canvas uses physical dimensions — a 27" monitor will appear larger than a 13" laptop
 - Enable **Snap to Grid** in the toolbar for precise alignment
+- Use the **↻** (rotate) button on a monitor to switch it between landscape and portrait
 - Click a monitor and press **Delete** to remove it
 - Press **F** to fit all monitors in view
+- Use the **config** button in the toolbar to save or load monitor layouts (e.g. desk vs laptop-only); configs are stored in your browser
 
 ### 3. Upload & Position Your Image
 
@@ -91,7 +57,13 @@ Drag monitors on the canvas to match your physical desk arrangement:
 - Click **Download** to save as PNG or JPEG
 - The output dimensions are displayed (e.g., "7280 x 1440")
 
-### 5. Set as Windows Wallpaper
+### 5. Windows Arrangement (optional)
+
+The **Windows Arrangement** tab (next to Physical Layout) lets you match how Windows sees your displays (Settings > System > Display). Use it if your Windows display order or positions don’t match a simple left-to-right layout.
+
+> **Warning:** Changing Windows Display Settings (position, order, resolution) can get messy. For best results, keep all monitors **top-aligned or bottom-aligned** in Windows; other alignments may produce unwanted (visible) black bars in the spanned wallpaper.
+
+### 6. Set as Windows Wallpaper
 
 1. Download the generated image
 2. Open **Settings > Personalization > Background**
@@ -106,7 +78,7 @@ Drag monitors on the canvas to match your physical desk arrangement:
 |--------|---------|
 | Pan | Scroll wheel / Right-click drag |
 | Horizontal pan | Shift + Scroll |
-| Zoom | Ctrl + Scroll |
+| Zoom | Ctrl + Scroll (up to 250%) |
 | Fit view | Press **F** / click **Fit** button |
 | Select monitor | Click on it |
 | Delete monitor | Select + **Delete** or **Backspace** |
@@ -173,6 +145,39 @@ src/
     └── ImageUpload.tsx        # File upload component
 ```
 
-## License
+## Running locally
 
-MIT
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+ (LTS recommended)
+- npm, yarn, or pnpm
+
+### Installation
+
+```bash
+git clone https://github.com/your-username/spanwright.git
+cd spanwright
+npm install
+```
+
+### Development
+
+```bash
+npm run dev
+```
+
+Opens at [http://localhost:5173](http://localhost:5173) by default.
+
+### Build for Production
+
+```bash
+npm run build
+```
+
+Output is in the `dist/` folder, ready for static hosting (e.g., Vercel, Netlify, GitHub Pages).
+
+### Preview Production Build
+
+```bash
+npm run preview
+```

--- a/src/components/InfoDialog.tsx
+++ b/src/components/InfoDialog.tsx
@@ -60,14 +60,14 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
           {/* Illustration placeholder */}
           <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
             <div className="flex items-center justify-center gap-6">
-              {/* Physical layout illustration */}
+              {/* Physical layout illustration — gap between monitors (your desk has physical space) */}
               <div className="text-center">
                 <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Your desk</div>
                 <div className="relative w-32 h-16">
                   <div className="absolute left-0 bottom-0 w-12 h-9 border border-cyan-500/60 bg-cyan-500/10 rounded-sm flex items-center justify-center">
                     <span className="text-[8px] text-cyan-400">Laptop</span>
                   </div>
-                  <div className="absolute right-0 top-0 w-20 h-14 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center">
+                  <div className="absolute left-14 top-0 w-18 h-14 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center">
                     <span className="text-[8px] text-blue-400">Monitor</span>
                   </div>
                 </div>
@@ -75,15 +75,17 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
 
               <div className="text-gray-600 text-lg">&rarr;</div>
 
-              {/* Windows arrangement illustration */}
+              {/* Windows arrangement illustration — one continuous strip, small gap so edges don’t mesh */}
               <div className="text-center">
                 <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Windows sees</div>
-                <div className="relative w-32 h-14">
-                  <div className="absolute left-0 top-0 w-10 h-8 border border-cyan-500/60 bg-cyan-500/10 rounded-sm flex items-center justify-center">
-                    <span className="text-[8px] text-cyan-400">1</span>
-                  </div>
-                  <div className="absolute right-0 top-0 w-18 h-12 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center" style={{ width: '72px', height: '48px', right: '0' }}>
-                    <span className="text-[8px] text-blue-400">2</span>
+                <div className="inline-block overflow-visible p-px">
+                  <div className="flex gap-px items-stretch">
+                    <div className="shrink-0 w-10 h-10 border border-cyan-500/60 bg-cyan-500/10 rounded-l-md rounded-r-sm flex items-center justify-center">
+                      <span className="text-[8px] text-cyan-400">1</span>
+                    </div>
+                    <div className="shrink-0 w-[72px] h-10 border border-blue-500/60 bg-blue-500/10 rounded-r-md rounded-l-sm flex items-center justify-center">
+                      <span className="text-[8px] text-blue-400">2</span>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/WindowsArrangementCanvas.tsx
+++ b/src/components/WindowsArrangementCanvas.tsx
@@ -446,13 +446,26 @@ export default function WindowsArrangementCanvas() {
         </button>
       </div>
 
+      {/* Baseline warning when customizing — in flow so it’s always visible */}
+      {state.useWindowsArrangement && (
+        <div className="shrink-0 px-4 py-2.5 bg-amber-950/70 border-b border-amber-700/50 space-y-1">
+          <p className="text-xs text-amber-200">
+            <strong>Note:</strong> Changing Windows Display Settings (position, order, resolution) can get messy.
+          </p>
+          <p className="text-xs text-amber-200">
+            For best results, keep all monitors <strong>top-aligned or bottom-aligned</strong> in Windows; other alignments may produce unwanted (visible) black bars in the spanned wallpaper.
+            For more info, see “How does this work?” in the top bar.
+          </p>
+        </div>
+      )}
+
       {/* Canvas area */}
       <div
         ref={containerRef}
-        className="flex-1 relative overflow-hidden"
+        className="flex-1 relative overflow-hidden min-h-0"
         style={{ cursor: state.useWindowsArrangement ? (dragging ? 'grabbing' : 'default') : 'default' }}
       >
-        {/* Warnings — overlaid so they don't shift the canvas layout */}
+        {/* Conditional warnings only (e.g. “differs significantly”) — overlaid on canvas */}
         {warnings.length > 0 && (
           <div className="absolute top-0 left-0 right-0 z-10 px-4 py-2 space-y-1 bg-yellow-900/80 backdrop-blur-sm border-b border-yellow-700/30 pointer-events-none">
             {warnings.map((w, i) => (


### PR DESCRIPTION
Warn against straying from top or bottom alignment in windows settings, update readme, fix small issue in 'how does this work' section with reversed images of display setups.