### PR TITLE
Add ability to use custom monitor names

### DIFF
--- a/src/components/ConfigManager.tsx
+++ b/src/components/ConfigManager.tsx
@@ -65,6 +65,7 @@ export default function ConfigManager() {
         physicalX: m.physicalX,
         physicalY: m.physicalY,
         rotation: m.rotation,
+        displayName: m.displayName,
       })),
     }
     const updated = [newConfig, ...configs].slice(0, MAX_CONFIGS)
@@ -79,7 +80,7 @@ export default function ConfigManager() {
     dispatch({ type: 'CLEAR_ALL_MONITORS' })
     // Add each monitor from the saved config
     for (const m of config.monitors) {
-      dispatch({ type: 'ADD_MONITOR', preset: m.preset, x: m.physicalX, y: m.physicalY, rotation: m.rotation ?? 0 })
+      dispatch({ type: 'ADD_MONITOR', preset: m.preset, x: m.physicalX, y: m.physicalY, rotation: m.rotation ?? 0, displayName: m.displayName })
     }
     setOpen(false)
   }

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback, type FormEvent } from 'react'
 import { useStore } from '../store'
 import { generateOutput, type OutputResult } from '../generateOutput'
+import { getMonitorDisplayName } from '../utils'
 
 
 export default function PreviewPanel() {
@@ -77,7 +78,7 @@ export default function PreviewPanel() {
       ctx.fillStyle = 'rgba(255,255,255,0.8)'
       ctx.font = '10px system-ui, sans-serif'
       ctx.textAlign = 'center'
-      const label = `${strip.monitor.preset.name} (${strip.stripWidth}x${strip.stripHeight})`
+      const label = `${getMonitorDisplayName(strip.monitor)} (${strip.stripWidth}x${strip.stripHeight})`
       ctx.fillText(label, x + w / 2, 12, w - 4)
 
       xOffset += strip.stripWidth

--- a/src/components/WindowsArrangementCanvas.tsx
+++ b/src/components/WindowsArrangementCanvas.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import { useStore } from '../store'
 import type { Monitor } from '../types'
+import { getMonitorDisplayName } from '../utils'
 import InfoDialog from './InfoDialog'
 
 const MONITOR_COLORS = [
@@ -273,7 +274,7 @@ export default function WindowsArrangementCanvas() {
         ctx.fillStyle = '#ffffff'
         ctx.font = 'bold 11px system-ui, sans-serif'
         ctx.textAlign = 'left'
-        ctx.fillText(mon.preset.name, x + 8, y + 17, labelW - 8)
+        ctx.fillText(getMonitorDisplayName(mon), x + 8, y + 17, labelW - 8)
 
         if (showRes) {
           ctx.fillStyle = '#94a3b8'

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -20,8 +20,9 @@ interface State {
 }
 
 type Action =
-  | { type: 'ADD_MONITOR'; preset: MonitorPreset; x: number; y: number; rotation?: 0 | 90 }
+  | { type: 'ADD_MONITOR'; preset: MonitorPreset; x: number; y: number; rotation?: 0 | 90; displayName?: string }
   | { type: 'REMOVE_MONITOR'; id: string }
+  | { type: 'SET_MONITOR_DISPLAY_NAME'; id: string; displayName: string }
   | { type: 'ROTATE_MONITOR'; id: string }
   | { type: 'CLEAR_ALL_MONITORS' }
   | { type: 'MOVE_MONITOR'; id: string; x: number; y: number }
@@ -87,13 +88,22 @@ function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'ADD_MONITOR': {
       const rotation = action.rotation ?? 0
-      const monitor = createMonitor(action.preset, action.x, action.y, rotation)
+      const monitor = createMonitor(action.preset, action.x, action.y, rotation, action.displayName)
       const newMonitors = [...state.monitors, monitor]
       return {
         ...state,
         monitors: newMonitors,
         selectedMonitorId: monitor.id,
         windowsArrangement: generateDefaultWindowsArrangement(newMonitors),
+      }
+    }
+    case 'SET_MONITOR_DISPLAY_NAME': {
+      const name = action.displayName.trim()
+      return {
+        ...state,
+        monitors: state.monitors.map(m =>
+          m.id === action.id ? { ...m, displayName: name || undefined } : m
+        ),
       }
     }
     case 'REMOVE_MONITOR': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface MonitorPreset {
 export interface Monitor {
   id: string
   preset: MonitorPreset
+  /** Custom display name (e.g. "Main display"). Falls back to preset.name when unset. */
+  displayName?: string
   // Physical position on canvas in inches (top-left corner)
   physicalX: number
   physicalY: number
@@ -52,6 +54,7 @@ export interface SavedConfig {
     physicalX: number
     physicalY: number
     rotation?: 0 | 90
+    displayName?: string
   }[]
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,7 @@ export function createMonitor(
   physicalX: number,
   physicalY: number,
   rotation: 0 | 90 = 0,
+  displayName?: string,
 ): Monitor {
   const ppi = calculatePPI(preset.resolutionX, preset.resolutionY, preset.diagonal)
   let { width, height } = calculatePhysicalDimensions(preset.resolutionX, preset.resolutionY, ppi)
@@ -37,6 +38,7 @@ export function createMonitor(
   return {
     id: uuidv4(),
     preset,
+    displayName,
     physicalX,
     physicalY,
     physicalWidth: width,
@@ -44,6 +46,11 @@ export function createMonitor(
     ppi,
     rotation,
   }
+}
+
+/** Display name for a monitor (custom name or preset name). */
+export function getMonitorDisplayName(monitor: Monitor): string {
+  return (monitor.displayName?.trim() || '') || monitor.preset.name
 }
 
 /**


### PR DESCRIPTION
Closes #16 

## PR Summary: Custom monitor display names

### Overview
Monitors can be given custom names (e.g. "Main display", "HP 23.8") via a pencil icon on the selected monitor. The chosen name is used everywhere (Physical Layout, Windows Arrangement, Export Preview) and is saved with Saved Layouts.

### Data model
- **Monitor** (`types.ts`): Optional `displayName?: string`.
- **SavedConfig** monitors: Optional `displayName` so renames persist when saving/loading layouts.
- **Store**: New action `SET_MONITOR_DISPLAY_NAME` (id + displayName). `ADD_MONITOR` accepts optional `displayName` (used when loading a layout).

### Utils
- **createMonitor** (`utils.ts`): Optional 5th argument `displayName`.
- **getMonitorDisplayName(monitor)**: Returns `monitor.displayName` (trimmed) or `monitor.preset.name` if no custom name.

### Physical Layout (EditorCanvas)
- Monitor label shows **getMonitorDisplayName(monitor)** instead of preset name only.
- When a monitor is **selected**, a **pencil icon** appears on the bottom row, to the **left** of the rotate button (fixed gap so they don’t overlap at 75% zoom).
- Clicking the pencil opens a **rename modal** (centered): input (current name, placeholder = preset name), Cancel, Done. Enter = Done, Escape or backdrop click = cancel. Empty name clears the custom name and falls back to preset name.
- Rename overlay uses a light dim (`bg-black/30`) with **no backdrop blur** so the canvas stays visible.

### Windows Arrangement
- **WindowsArrangementCanvas**: Canvas labels use **getMonitorDisplayName(mon)** instead of `mon.preset.name`.

### Export Preview
- **PreviewPanel**: Strip labels use **getMonitorDisplayName(strip.monitor)** so the same names appear in the preview.

### Saved Layouts
- **ConfigManager**: Saves and loads `displayName` for each monitor so custom names are stored and restored with layouts.