### PR TITLE
Additional fixes for handling grids with vertically stacked monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Spanright operates in **physical space** (inches/cm), so you arrange monitors as
 - **Monitor rotation** — Rotate any monitor 90° (portrait/landscape) via the ↻ button on each monitor tile. Resolution is swapped (e.g. 1080×1920 when rotated); rotation is saved in saved layouts and reflected in output and the Windows Arrangement view.
 - **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display. Vertical images (height > width) default to 6 ft tall; horizontal ones default to 6 ft wide.
 - **Smart image recommendations** — Calculates the minimum source image resolution needed based on your layout's physical size and the highest-PPI monitor.
-- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches the results side-by-side. Handles vertical offsets and fills empty space with black.
+- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's Windows arrangement position (side-by-side, stacked, or mixed). Fills any gaps in the layout with black.
 - **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
 - **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom (up to 250%), right-click drag to pan. Custom scrollbars, snap-to-grid, and fit-to-view.
 - **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, Windows arrangement). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Basic but very useful for multi-setup workflows.
@@ -108,14 +108,13 @@ For example, a 27" QHD (2560x1440) monitor:
 
 ### Output Generation
 
-For each monitor (sorted left-to-right by physical position):
-1. Determine the physical bounding box on the canvas
-2. Find the overlapping region of the source image
-3. Map physical coordinates back to source image pixels
-4. Crop and scale that region to the monitor's native resolution
-5. Stitch all strips side-by-side into the final output
+Output matches the Windows virtual desktop bounding box (Settings > Display). For each monitor:
 
-The output height equals the tallest monitor's resolution. Shorter monitors are vertically positioned based on their physical offset, with black fill for empty space.
+1. **Physical layout** determines what portion of the source image that monitor sees.
+2. **Windows arrangement** (pixel positions) determines where the monitor sits in the output image.
+3. The source image is cropped and scaled to the monitor's native resolution (PPI-correct).
+4. Each monitor is drawn at its `(pixelX, pixelY)` position in the output. This supports side-by-side, stacked vertical, and mixed layouts.
+5. Output dimensions = bounding box of all monitors (`maxX − minX` × `maxY − minY`). Any unfilled area (gaps or differing sizes) is filled with black.
 
 ## Tech Stack
 
@@ -138,11 +137,15 @@ src/
 ├── generateOutput.ts          # Wallpaper stitching logic
 ├── index.css                  # Tailwind imports
 └── components/
-    ├── EditorCanvas.tsx       # Interactive canvas editor
-    ├── MonitorPresetsSidebar.tsx  # Preset list + custom form
-    ├── Toolbar.tsx            # Top toolbar controls
-    ├── PreviewPanel.tsx       # Output preview + download
-    └── ImageUpload.tsx        # File upload component
+    ├── EditorCanvas.tsx           # Physical layout canvas
+    ├── WindowsArrangementCanvas.tsx  # Windows display-order canvas
+    ├── MonitorPresetsSidebar.tsx   # Preset list + custom form
+    ├── Toolbar.tsx                 # Top toolbar controls
+    ├── PreviewPanel.tsx            # Output preview + download
+    ├── ImageUpload.tsx             # File upload component
+    ├── ConfigManager.tsx            # Saved layouts (save/load)
+    ├── InfoDialog.tsx              # App info / keyboard shortcuts
+    └── TroubleshootingGuide.tsx     # Wallpaper troubleshooting
 ```
 
 ## Running locally

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -62,26 +62,25 @@ export default function PreviewPanel() {
     ctx.fillRect(0, 0, canvas.width, canvas.height)
     ctx.drawImage(output.canvas, 0, 0, canvas.width, canvas.height)
 
-    // Draw monitor strip boundaries
-    let xOffset = 0
+    // Draw monitor strip boundaries and labels (each at its actual position)
     for (const strip of output.monitors) {
-      const x = Math.round(xOffset * displayScale)
+      const x = Math.round(strip.stripX * displayScale)
+      const y = Math.round(strip.stripY * displayScale)
       const w = Math.round(strip.stripWidth * displayScale)
+      const h = Math.round(strip.stripHeight * displayScale)
 
       ctx.strokeStyle = 'rgba(255,255,255,0.25)'
       ctx.lineWidth = 1
-      ctx.strokeRect(x + 0.5, 0.5, w - 1, canvas.height - 1)
+      ctx.strokeRect(x + 0.5, y + 0.5, w - 1, h - 1)
 
-      // Label
+      // Label at top of this monitor
       ctx.fillStyle = 'rgba(0,0,0,0.65)'
-      ctx.fillRect(x, 0, w, 18)
+      ctx.fillRect(x, y, w, 18)
       ctx.fillStyle = 'rgba(255,255,255,0.8)'
       ctx.font = '10px system-ui, sans-serif'
       ctx.textAlign = 'center'
       const label = `${getMonitorDisplayName(strip.monitor)} (${strip.stripWidth}x${strip.stripHeight})`
-      ctx.fillText(label, x + w / 2, 12, w - 4)
-
-      xOffset += strip.stripWidth
+      ctx.fillText(label, x + w / 2, y + 12, w - 4)
     }
   }, [output])
 
@@ -245,7 +244,7 @@ export default function PreviewPanel() {
       {output?.hasBlackBars && (
         <div className="shrink-0 px-4 py-2 bg-gray-800/80 border-b border-gray-700/50">
           <p className="text-xs text-gray-400">
-            Black bars in the preview are normal — they fill the negative space around your displays and <strong className="text-gray-300">should not be visible</strong> on the monitors themselves.
+            Black bars in the preview are normal — they fill the negative space around your displays and shouldn’t be visible on the monitors themselves.
           </p>
         </div>
       )}


### PR DESCRIPTION
## PR Summary

### Preview: labels on every monitor when stacked
- **Issue:** When multiple monitors (including same-name) were stacked vertically, the preview only showed a label on the top one.
- **Change:** Output now includes each monitor’s position (`stripX`, `stripY`). The preview draws boundaries and labels at each monitor’s actual rect, so every monitor gets a label at the top of its segment.
- **Files:** `src/generateOutput.ts` (extend strip type and pass-through position), `src/components/PreviewPanel.tsx` (use position for rects/labels instead of a single horizontal row).

### Fix: `hasBlackBars` only when there are real gaps
- **Issue:** The “black bars” note appeared even when monitors fully tiled the output (e.g. four aligned monitors), because the logic treated “any monitor not spanning full width/height” as having black bars.
- **Change:** `hasBlackBars` is now based on coverage: `(sum of monitor areas) < (bounding box area)`. The note only shows when the layout has unfilled pixels (gaps or differing sizes).
- **Files:** `src/generateOutput.ts`.

### README: align with current behavior and structure
- **Output generation:** Reworded to describe Windows virtual desktop bounding box, physical vs Windows arrangement, and drawing at `(pixelX, pixelY)` for side-by-side, stacked, and mixed layouts.
- **Features:** Updated output bullet to mention Windows arrangement and “gaps” instead of only “side-by-side”.
- **Project structure:** Listed missing components: `WindowsArrangementCanvas`, `ConfigManager`, `InfoDialog`, `TroubleshootingGuide`.
- **Files:** `README.md`.