### PR TITLE
Fixed arrow keys and delete/backspace affecting monitors when typing in other fields, remove scrollbar from preview

### DIFF
--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -232,9 +232,18 @@ export default function EditorCanvas() {
     return () => observer.disconnect()
   }, [])
 
-  // Keyboard shortcuts
+  // Keyboard shortcuts (skip when typing in inputs so we don't delete monitors or nudge)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = document.activeElement
+      const isEditable = target && (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        (target as HTMLElement).isContentEditable
+      )
+      if (isEditable) return
+
       // Delete selected monitor
       if ((e.key === 'Delete' || e.key === 'Backspace') && state.selectedMonitorId && !imageSelected) {
         dispatch({ type: 'REMOVE_MONITOR', id: state.selectedMonitorId })

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -50,8 +50,9 @@ export default function PreviewPanel() {
     if (!canvas || !container || !output) return
 
     const ctx = canvas.getContext('2d')!
-    const containerWidth = container.clientWidth - 64
-    const containerHeight = container.clientHeight - 32
+    // p-8 = 32px each side (64 total); canvas has border-2 = 4px extra per axis
+    const containerWidth = container.clientWidth - 64 - 4
+    const containerHeight = container.clientHeight - 64 - 4
 
     // Scale to fit container
     const displayScale = Math.min(1, containerWidth / output.width, containerHeight / output.height)


### PR DESCRIPTION
## PR Summary

### 1. Ignore canvas shortcuts when typing in inputs

**Problem:** With a monitor selected, using the keyboard in the Save Layout name field, preset filter, or custom monitor fields still triggered canvas actions: Backspace/Delete removed the monitor, arrow keys nudged it, and F / Escape could trigger fit or deselect.

**Solution:** At the start of the global `keydown` handler in `EditorCanvas`, we skip all shortcut handling when the active element is an input, textarea, select, or contenteditable. Typing in any of those controls no longer affects the canvas.

### 2. Remove tiny horizontal scrollbar on preview

**Problem:** The preview area showed a small horizontal scrollbar because the canvas was sized as if it had no border, while the preview canvas uses `border-2` (4px extra width and height). Vertical padding was also under-accounted (32px instead of 64px).

**Solution:** When computing the available size for the preview canvas, subtract the full padding (64px for `p-8` on both axes) and the canvas border (4px per axis). The canvas element (content + border) now fits inside the padded container without overflow.