### PR TITLE
Fixed image resizing

### DIFF
--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -99,16 +99,7 @@ export default function ImageUpload() {
           <span className="text-xs text-gray-500 shrink-0">
             ({state.sourceImage.naturalWidth} x {state.sourceImage.naturalHeight} px)
           </span>
-          <button
-            onClick={() => dispatch({ type: 'ROTATE_SOURCE_IMAGE' })}
-            className="text-xs text-gray-400 hover:text-gray-200 transition-colors flex items-center gap-1 shrink-0"
-            title="Rotate image 90° clockwise"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
-            Rotate
-          </button>
+          {/* TODO: Source image rotation (90/270°) — preview crop/position is unreliable for some monitors; re-enable when fixed. Store/ROTATE_SOURCE_IMAGE kept for saved layouts. */}
           <button
             onClick={() => fileInputRef.current?.click()}
             className="text-xs text-blue-400 hover:text-blue-300 transition-colors shrink-0 whitespace-nowrap"


### PR DESCRIPTION
## PR Summary

### Image resize: delete (X) button tracks top-right corner

**Problem:** While resizing the source image with the Transformer, the delete (X) button did not follow the image’s top-right corner. It either stayed fixed (only scaling in X) or, with a previous fix, jumped around or disappeared because of wrong coordinate conversion.

**Solution:** Position the button from the image’s bounding box in the **Group** coordinate system so no manual stage conversion is needed:

- On **`onTransform`**: call `imageRef.current.getClientRect({ skipTransform: false, relativeTo: group })` (with `group = node.getParent()`). The box is in the same space as the button (both live in the Group).
- Set button position to top-right of that box: `x = box.x + box.width - 22`, `y = box.y + 4`.
- Store that in state as `imageDeleteButtonPos: { x, y } | null` and use it while transforming; when `null` (not resizing), use the default `(imgW - 22, 4)`.
- Only call `setImageDeleteButtonPos` when both `x` and `y` are finite to avoid bad values from Konva.
- In **`onTransformEnd`**: set `imageDeleteButtonPos` back to `null` so the button sits at the correct top-right for the new size.

**Result:** The X follows the visual top-right for every resize handle (bottom-right, top-right, bottom-left, top-left) without jumping or flying off.

---

Also made image rotation a TODO and hid button for now.