### PR TITLE
Lots of changes to instructions and labels (including instructions for other OSes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
 # Spanright — Multi-Monitor Wallpaper Alignment Tool
 
-Spanright is a single-page web app that lets you create pixel-perfect spanning wallpapers for non-standard multi-monitor setups. Windows' "span" wallpaper mode concatenates monitors by pixel resolution, ignoring physical size differences — Spanright solves this by letting you model your physical desk layout, position a source image across it, and export a stitched wallpaper that looks seamless when spanned.
+Spanright is a single-page web app that lets you create pixel-perfect spanning wallpapers for non-standard multi-monitor setups. Most operating systems concatenate monitors by pixel resolution when spanning wallpapers, ignoring physical size differences — Spanright solves this by letting you model your physical desk layout, position a source image across it, and export a stitched wallpaper that looks seamless across all your screens. Works on Windows, macOS, and Linux.
 
 ## The Problem
 
-If you have monitors of different sizes or resolutions (e.g., a 15.6" laptop next to a 27" QHD desktop), Windows span mode produces misaligned wallpapers. A single wide image gets split based on raw pixel counts, not physical dimensions. A mountain peak that should flow across both screens ends up with a jarring offset.
+If you have monitors of different sizes or resolutions (e.g., a 15.6" laptop next to a 27" QHD desktop), spanning a single wallpaper produces misaligned images. The image gets split based on raw pixel counts, not physical dimensions. A mountain peak that should flow across both screens ends up with a jarring offset.
 
-Spanright operates in **physical space** (inches/cm), so you arrange monitors as they actually sit on your desk. It then renders each monitor's portion of the source image at the correct PPI, producing one output image that Windows can span correctly.
+Spanright operates in **physical space** (inches/cm), so you arrange monitors as they actually sit on your desk. It then renders each monitor's portion of the source image at the correct PPI, producing one output image that your OS can span correctly.
 
 ## Features
 
 - **Physical-space monitor layout** — Arrange monitors on a canvas using real-world dimensions (calculated from diagonal size + resolution). A 27" monitor appears physically larger than a 15.6" laptop, exactly as on your desk.
 - **Drag-and-drop presets** — Choose from 18+ built-in monitor presets (laptops, standard monitors, ultrawides, super ultrawides) and drag them directly onto the canvas.
-- **Custom monitors** — Define any monitor by diagonal size, aspect ratio, and resolution. Supports fully custom resolution entry or filtered presets by aspect ratio. Diagonal is limited to 5"–120"; aspect ratio is limited to 10:1 or less (no ultra-thin “line” monitors). Validation warnings appear when limits are exceeded; Add is disabled until fixed.
-- **Monitor rotation** — Rotate any monitor 90° (portrait/landscape) via the ↻ button on each monitor tile. Resolution is swapped (e.g. 1080×1920 when rotated); rotation is saved in saved layouts and reflected in output and the Windows Arrangement view.
+- **Custom monitors** — Define any monitor by diagonal size, aspect ratio, and resolution. Supports fully custom resolution entry or filtered presets by aspect ratio. Diagonal is limited to 5"–120"; aspect ratio is limited to 10:1 or less (no ultra-thin "line" monitors). Validation warnings appear when limits are exceeded; Add is disabled until fixed.
+- **Monitor rotation** — Rotate any monitor 90° (portrait/landscape) via the ↻ button on each monitor tile. Resolution is swapped (e.g. 1080×1920 when rotated); rotation is saved in saved layouts and reflected in output and the Virtual Layout view.
 - **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display. Vertical images (height > width) default to 6 ft tall; horizontal ones default to 6 ft wide.
 - **Smart image recommendations** — Calculates the minimum source image resolution needed based on your layout's physical size and the highest-PPI monitor.
-- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's Windows arrangement position (side-by-side, stacked, or mixed). Fills any gaps in the layout with black.
+- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's virtual layout position (side-by-side, stacked, or mixed). Fills any gaps in the layout with black.
 - **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
 - **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom (up to 300%), right-click drag to pan. Custom scrollbars, Align Assist guides/snapping, and fit-to-view.
-- **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, Windows arrangement). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Basic but very useful for multi-setup workflows.
+- **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, virtual layout). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Basic but very useful for multi-setup workflows.
+- **Cross-platform** — Works in any modern browser. Output can be applied as a spanned wallpaper on Windows (Span/Tile mode), macOS (per-monitor crop), and Linux (varies by DE — GNOME, KDE, feh, swaybg, etc.).
 
 ## Example
 Dragon image [source](https://unsplash.com/photos/dragon-effigy-breathes-fire-over-a-crowd-at-night-TP7InDDpeRE) from Unsplash.
 ### Physical Layout & Editor Canvas
 <img width="1920" height="1039" alt="dragonfire-canvas-zoomed" src="https://github.com/user-attachments/assets/26e5b87c-73d8-4ce9-af2a-90069d98f721" />
 
-### Windows Arrangement
+### Virtual Layout
 <img width="1920" height="1039" alt="dragonfire-windows" src="https://github.com/user-attachments/assets/564adb2d-9b27-4f4e-8afe-2d7601512303" />
 
 ### Preview & Export
@@ -76,26 +77,69 @@ Drag monitors on the canvas to match your physical desk arrangement:
 - With **Align Assist** enabled, image drag/resize shows green alignment guides against monitor edges/centers
 - Check the **recommended image size** banner in the toolbar — green means your image is large enough, yellow/red means it may appear pixelated
 
-### 4. Preview & Export
+### 4. Virtual Layout (optional)
+
+The **Virtual Layout** tab (next to Physical Layout) lets you match how your OS sees your displays. Use it if your display order or positions don't match a simple left-to-right layout. This concept applies on all platforms — Windows, macOS, and Linux all maintain their own display arrangement.
+
+#### Windows
+Open **Settings > System > Display** to see how Windows arranges your monitors. If the order matches a simple left-to-right layout, you can skip this step.
+
+> **Warning:** Changing Windows Display Settings (position, order, resolution) can get messy. For best results, keep all monitors **top-aligned or bottom-aligned** in Windows; other alignments may produce unwanted (visible) black bars in the spanned wallpaper.
+
+#### macOS
+Open **System Settings > Displays > Arrange** to see your display arrangement. Drag the display rectangles to match your physical layout.
+
+> **Note:** Retina/HiDPI displays report logical pixels (e.g. "looks like 1440×900"), not the actual hardware resolution (e.g. 2880×1800). When adding monitors in Spanright, always use the **actual pixel resolution** — otherwise the output will be undersized and blurry on Retina screens.
+
+#### Linux
+Display arrangement depends on your desktop environment:
+- **GNOME:** Settings > Displays
+- **KDE Plasma:** System Settings > Display and Monitor > Display Configuration
+- **Command line:** `xrandr --query` (X11) or `wlr-randr` (Wayland/wlroots)
+
+### 5. Preview & Export
 
 - The bottom panel shows a live preview of the final stitched wallpaper
 - Click **Download** to save as PNG or JPEG
 - The output dimensions are displayed (e.g., "7280 x 1440")
 
-### 5. Windows Arrangement (optional)
+### 6. Set Your Wallpaper
 
-The **Windows Arrangement** tab (next to Physical Layout) lets you match how Windows sees your displays (Settings > System > Display). Use it if your Windows display order or positions don’t match a simple left-to-right layout.
-
-> **Warning:** Changing Windows Display Settings (position, order, resolution) can get messy. For best results, keep all monitors **top-aligned or bottom-aligned** in Windows; other alignments may produce unwanted (visible) black bars in the spanned wallpaper.
-
-### 6. Set as Windows Wallpaper
-
+#### Windows
 1. Download the generated image
 2. Open **Settings > Personalization > Background**
 3. Set "Choose a fit" to **Span**
 4. Select the downloaded image
 
 > **Important:** Make sure your Windows display arrangement (Settings > Display) matches the physical layout you configured in Spanright.
+
+#### macOS
+macOS has no native "Span" wallpaper mode. To use the Spanright output:
+1. Download the generated image
+2. Open it in **Preview** or an image editor and crop each monitor's region individually
+3. Open **System Settings > Wallpaper** (or right-click desktop > **Change Wallpaper**)
+4. Set each monitor's wallpaper individually using its cropped portion
+
+> **Tip:** Third-party tools like **Multi Monitor Wallpaper** can automate spanning a single image across all displays.
+
+#### Linux
+Linux wallpaper handling varies by desktop environment:
+- **GNOME:** Settings > Background, then select the image. Use `gsettings set org.gnome.desktop.background picture-options 'spanned'` to span across monitors.
+- **KDE Plasma:** Right-click desktop > Configure Desktop > Wallpaper. Some versions support spanning directly.
+- **feh (X11):** `feh --bg-scale /path/to/wallpaper.png`
+- **nitrogen (X11):** Select the image and choose "Scaled" or "Zoomed" fitting.
+- **swaybg (Wayland/Sway):** `swaybg -i /path/to/wallpaper.png -m fill`
+- **Hyprpaper (Hyprland):** Configure in `~/.config/hypr/hyprpaper.conf`
+
+> **Note:** Exact steps vary by distribution and desktop environment. If your tool doesn't support spanning, crop per-monitor regions from the output (like macOS) and set each individually.
+
+## Platform Support
+
+| Platform | Span Mode | Display Settings | Notes |
+|----------|-----------|------------------|-------|
+| **Windows** | Built-in (**Span** or **Tile** fit mode) | Settings > System > Display | Best native support — Span mode applies one image across all monitors automatically |
+| **macOS** | No native span mode | System Settings > Displays > Arrange | Crop per-monitor from the Spanright output and set each individually. Retina displays report logical pixels — use actual hardware resolution in Spanright |
+| **Linux** | Varies by DE | GNOME Settings, KDE System Settings, `xrandr`, etc. | GNOME supports `spanned` picture option. Other DEs/WMs may require per-monitor cropping or tools like `feh`, `nitrogen`, or `swaybg` |
 
 ## Canvas Controls
 
@@ -133,10 +177,10 @@ For example, a 27" QHD (2560x1440) monitor:
 
 ### Output Generation
 
-Output matches the Windows virtual desktop bounding box (Settings > Display). For each monitor:
+Output matches the virtual desktop bounding box of your virtual layout. For each monitor:
 
 1. **Physical layout** determines what portion of the source image that monitor sees.
-2. **Windows arrangement** (pixel positions) determines where the monitor sits in the output image.
+2. **Virtual layout** (pixel positions) determines where the monitor sits in the output image.
 3. The source image is cropped and scaled to the monitor's native resolution (PPI-correct).
 4. Each monitor is drawn at its `(pixelX, pixelY)` position in the output. This supports side-by-side, stacked vertical, and mixed layouts.
 5. Output dimensions = bounding box of all monitors (`maxX − minX` × `maxY − minY`). Any unfilled area (gaps or differing sizes) is filled with black.
@@ -163,7 +207,7 @@ src/
 ├── index.css                  # Tailwind imports
 └── components/
     ├── EditorCanvas.tsx           # Physical layout canvas
-    ├── WindowsArrangementCanvas.tsx  # Windows display-order canvas
+    ├── WindowsArrangementCanvas.tsx  # Virtual layout canvas
     ├── MonitorPresetsSidebar.tsx   # Preset list + custom form
     ├── Toolbar.tsx                 # Top toolbar controls
     ├── PreviewPanel.tsx            # Output preview + download

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ function AboutDialog({ onClose }: { onClose: () => void }) {
             Multi-Monitor Wallpaper Alignment Tool
           </p>
           <p className="text-sm text-gray-300">
-            Source code on{' '}
+            Source code and documentation on{' '}
             <a
               href="https://github.com/andresjmorales/spanright"
               target="_blank"
@@ -125,15 +125,15 @@ function WelcomeDialog({ onClose }: { onClose: () => void }) {
             <li className="flex items-start gap-3">
               <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">3</span>
               <div>
-                <div className="text-sm font-medium text-gray-200">Check your Windows arrangement</div>
-                <div className="text-xs text-gray-400 mt-0.5">The <strong className="text-gray-300">Windows Arrangement</strong> tab lets you match how your displays are set up in Windows Settings, if needed.</div>
+                <div className="text-sm font-medium text-gray-200">Check your virtual layout</div>
+                <div className="text-xs text-gray-400 mt-0.5">The <strong className="text-gray-300">Virtual Layout</strong> tab lets you match how your displays are arranged in your OS display settings, if needed.</div>
               </div>
             </li>
             <li className="flex items-start gap-3">
               <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
               <div>
                 <div className="text-sm font-medium text-gray-200">Preview &amp; export</div>
-                <div className="text-xs text-gray-400 mt-0.5">Head to <strong className="text-gray-300">Preview &amp; Export</strong> to see the stitched result and download it. Set the wallpaper in Windows using <strong className="text-gray-300">Span</strong> mode.</div>
+                <div className="text-xs text-gray-400 mt-0.5">Head to <strong className="text-gray-300">Preview &amp; Export</strong> to see the stitched result and download it. On Windows, use <strong className="text-gray-300">Span</strong> mode; on macOS/Linux, see the troubleshooting guide for setup steps.</div>
               </div>
             </li>
           </ol>
@@ -218,7 +218,7 @@ function AppContent() {
       {/* Tabs */}
       <div className="bg-gray-900 border-b border-gray-700 px-4 flex items-end gap-1 shrink-0">
         <TabButton tab="physical" label="Physical Layout" active={tab === 'physical'} onClick={setTab} />
-        <TabButton tab="windows" label="Windows Arrangement" active={tab === 'windows'} onClick={setTab} />
+        <TabButton tab="windows" label="Virtual Layout" active={tab === 'windows'} onClick={setTab} />
         <TabButton tab="preview" label="Preview & Export" active={tab === 'preview'} onClick={setTab} />
       </div>
 

--- a/src/components/InfoDialog.tsx
+++ b/src/components/InfoDialog.tsx
@@ -24,10 +24,10 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
           {/* Title */}
           <div>
             <h2 className="text-lg font-semibold text-gray-100">
-              How Windows Span Mode Works
+              How Spanright Generates Your Wallpaper
             </h2>
             <p className="text-xs text-gray-500 mt-0.5">
-              Understanding how Spanright generates your wallpaper
+              Understanding how the two layout tabs work together
             </p>
           </div>
 
@@ -36,9 +36,9 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
             <div className="flex items-start gap-3">
               <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">1</span>
               <div>
-                <h3 className="text-sm font-medium text-gray-200">One wide image, stretched across all screens</h3>
+                <h3 className="text-sm font-medium text-gray-200">One wide image, sized to your virtual layout</h3>
                 <p className="text-xs text-gray-400 mt-1 leading-relaxed">
-                  Spanright generates a single wide image that Windows will stretch across all your monitors using <strong className="text-gray-300">Span</strong> mode. Each monitor gets a slice of this image.
+                  Spanright generates a single wide image that covers your entire multi-monitor setup. On Windows, you apply it using <strong className="text-gray-300">Span</strong> mode; on other platforms you may need to crop per-monitor or use a wallpaper tool that supports spanning. Each monitor gets the correct slice of this image.
                 </p>
               </div>
             </div>
@@ -49,21 +49,20 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
             <div className="flex items-start gap-3">
               <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">2</span>
               <div>
-                <h3 className="text-sm font-medium text-gray-200">Windows uses its own display arrangement</h3>
+                <h3 className="text-sm font-medium text-gray-200">Your OS uses its own display arrangement</h3>
                 <p className="text-xs text-gray-400 mt-1 leading-relaxed">
-                  Windows paints this image based on how your monitors are arranged in <strong className="text-gray-300">Settings &gt; Display</strong>, starting from the top-left corner. The left-to-right order and vertical offsets in Windows determine which slice each monitor gets.
+                  Your operating system paints this image based on how your monitors are arranged in your display settings, starting from the top-left corner. The left-to-right order and vertical offsets determine which slice each monitor gets.
                 </p>
                 <p className="text-xs text-gray-400 mt-1.5 leading-relaxed">
-                  Spanright’s output is the <strong className="text-gray-300">bounding box</strong> of that arrangement — the smallest rectangle that contains all your monitors. So side-by-side, stacked vertically, or any mix all work: the image size matches the virtual desktop Windows uses.
+                  Spanright's output is the <strong className="text-gray-300">bounding box</strong> of that arrangement — the smallest rectangle that contains all your monitors. Side-by-side, stacked vertically, or any mix all work: the image size matches the virtual desktop your OS uses.
                 </p>
               </div>
             </div>
           </section>
 
-          {/* Illustration placeholder */}
+          {/* Illustration */}
           <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
             <div className="flex items-center justify-center gap-6">
-              {/* Physical layout illustration — gap between monitors (your desk has physical space) */}
               <div className="text-center">
                 <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Your desk</div>
                 <div className="relative w-32 h-16">
@@ -78,9 +77,8 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
 
               <div className="text-gray-600 text-lg">&rarr;</div>
 
-              {/* Windows arrangement illustration — one continuous strip, small gap so edges don’t mesh */}
               <div className="text-center">
-                <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Windows sees</div>
+                <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Your OS sees</div>
                 <div className="inline-block overflow-visible p-px">
                   <div className="flex gap-px items-stretch">
                     <div className="shrink-0 w-10 h-10 border border-cyan-500/60 bg-cyan-500/10 rounded-l-md rounded-r-sm flex items-center justify-center">
@@ -102,7 +100,7 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
               <div>
                 <h3 className="text-sm font-medium text-gray-200">Two layouts, one wallpaper</h3>
                 <p className="text-xs text-gray-400 mt-1 leading-relaxed">
-                  The <strong className="text-gray-300">Physical Layout</strong> tab controls what part of your image each monitor shows — based on real-world size and position on your desk. The <strong className="text-gray-300">Windows Arrangement</strong> tab controls how the output image is stitched together — matching how Windows will paint it.
+                  The <strong className="text-gray-300">Physical Layout</strong> tab controls what part of your image each monitor shows — based on real-world size and position on your desk. The <strong className="text-gray-300">Virtual Layout</strong> tab controls how the output image is stitched together — matching how your OS will paint it.
                 </p>
               </div>
             </div>
@@ -113,23 +111,48 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
             <div className="flex items-start gap-3">
               <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
               <div>
-                <h3 className="text-sm font-medium text-gray-200">You don't need to change Windows settings</h3>
+                <h3 className="text-sm font-medium text-gray-200">You don't need to change your OS settings</h3>
                 <p className="text-xs text-gray-400 mt-1 leading-relaxed">
-                  Just tell Spanright how your monitors are currently arranged in Windows. If your Windows arrangement roughly matches your physical layout with monitors top-aligned, you can skip this step entirely — the default "auto-aligned" option handles it.
+                  Just tell Spanright how your monitors are currently arranged in your OS display settings. If your arrangement roughly matches your physical layout with monitors top-aligned, you can skip this step entirely — the default "auto-aligned" option handles it.
                 </p>
               </div>
             </div>
           </section>
 
-          {/* How to check */}
-          <div className="bg-gray-800/30 border border-gray-700/50 rounded-lg p-3 space-y-1.5">
-            <div className="text-xs font-medium text-gray-300">How to check your Windows arrangement:</div>
-            <ol className="text-xs text-gray-400 space-y-1 list-decimal list-inside">
-              <li>Open <strong className="text-gray-300">Settings &gt; System &gt; Display</strong></li>
-              <li>Look at the monitor rectangles at the top of the page</li>
-              <li>Note their left-to-right order and vertical positions</li>
-              <li>Replicate that layout in the Windows Arrangement tab</li>
-            </ol>
+          {/* How to check — platform-specific */}
+          <div className="bg-gray-800/30 border border-gray-700/50 rounded-lg p-3 space-y-3">
+            <div className="text-xs font-medium text-gray-300">How to check your display arrangement (to replicate in the Virtual Layout tab):</div>
+
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold text-blue-400 uppercase tracking-wider">Windows</div>
+              <ol className="text-xs text-gray-400 space-y-1 list-decimal list-inside">
+                <li>Open <strong className="text-gray-300">Settings &gt; System &gt; Display</strong></li>
+                <li>Look at the monitor rectangles at the top of the page</li>
+                <li>Note their left-to-right order and vertical positions</li>
+                <li>Replicate that layout in the Virtual Layout tab</li>
+              </ol>
+            </div>
+
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold text-blue-400 uppercase tracking-wider">macOS</div>
+              <ol className="text-xs text-gray-400 space-y-1 list-decimal list-inside">
+                <li>Open <strong className="text-gray-300">System Settings &gt; Displays &gt; Arrange</strong></li>
+                <li>Note the position of each display rectangle</li>
+                <li>Replicate that layout in the Virtual Layout tab</li>
+              </ol>
+              <p className="text-[10px] text-gray-500 mt-1 leading-relaxed">
+                Retina/HiDPI displays report logical pixels, not physical pixels. Use your display's actual pixel resolution (e.g. 2880&times;1800, not the scaled resolution) when adding monitors in Spanright.
+              </p>
+            </div>
+
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold text-blue-400 uppercase tracking-wider">Linux</div>
+              <ol className="text-xs text-gray-400 space-y-1 list-decimal list-inside">
+                <li>Open your DE's display settings (<strong className="text-gray-300">GNOME Settings &gt; Displays</strong>, <strong className="text-gray-300">KDE System Settings &gt; Display</strong>, or use <strong className="text-gray-300">xrandr</strong>)</li>
+                <li>Note the monitor positions and order</li>
+                <li>Replicate that layout in the Virtual Layout tab</li>
+              </ol>
+            </div>
           </div>
 
           {/* Close button */}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -263,7 +263,7 @@ export default function PreviewPanel() {
       {state.useWindowsArrangement && (
         <div className="px-4 py-2 border-t border-gray-800 bg-gray-900 shrink-0">
           <div className="text-xs text-gray-500">
-            Output uses your custom Windows arrangement for monitor ordering and vertical offsets.
+            Output uses your custom virtual layout for monitor ordering and vertical offsets.
           </div>
         </div>
       )}

--- a/src/components/TroubleshootingGuide.tsx
+++ b/src/components/TroubleshootingGuide.tsx
@@ -4,6 +4,8 @@ interface TroubleshootingGuideProps {
   onClose: () => void
 }
 
+type Platform = 'windows' | 'macos' | 'linux'
+
 function AccordionSection({ title, children, defaultOpen = false }: { title: string; children: React.ReactNode; defaultOpen?: boolean }) {
   const [open, setOpen] = useState(defaultOpen)
 
@@ -33,7 +35,267 @@ function AccordionSection({ title, children, defaultOpen = false }: { title: str
   )
 }
 
+function PlatformTabs({ active, onChange }: { active: Platform; onChange: (p: Platform) => void }) {
+  const tabs: { id: Platform; label: string }[] = [
+    { id: 'windows', label: 'Windows' },
+    { id: 'macos', label: 'macOS' },
+    { id: 'linux', label: 'Linux' },
+  ]
+  return (
+    <div className="flex gap-1 bg-gray-800/50 rounded-lg p-1">
+      {tabs.map(t => (
+        <button
+          key={t.id}
+          onClick={() => onChange(t.id)}
+          className={`flex-1 text-xs font-medium px-3 py-1.5 rounded-md transition-colors ${
+            active === t.id
+              ? 'bg-gray-700 text-gray-100'
+              : 'text-gray-400 hover:text-gray-300 hover:bg-gray-800/60'
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function WindowsContent() {
+  return (
+    <>
+      {/* Priority Tip Callout */}
+      <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-blue-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="text-sm font-semibold text-blue-300">
+            If Span isn't working, try Tile
+          </h3>
+        </div>
+        <p className="text-sm text-gray-300 leading-relaxed">
+          Your wallpaper is designed for Windows <strong className="text-blue-300">Span</strong> mode, and that should work perfectly in most setups. But if you're seeing stretching, bleed, or misalignment, try switching to <strong className="text-blue-300">Tile</strong> instead: right-click your desktop &gt; Personalize &gt; Background, and change the fit mode.
+        </p>
+        <p className="text-xs text-gray-400 leading-relaxed">
+          <strong className="text-gray-300">Why does this help?</strong> Span mode scales your image to fit the Windows virtual desktop bounding box — the exterior rectangle that contains your entire display setup (side-by-side, stacked vertical, or mixed). If any monitor is even a few pixels offset, Windows will stretch the image to compensate, causing visible bleed. Tile mode places the image at exact 1:1 pixel scale with no resizing, bypassing the issue entirely.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <AccordionSection title="I see a few pixels of overflow/bleed between monitors">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            This usually means your Windows display arrangement has a small vertical offset. Even a few pixels will cause Windows to scale your wallpaper.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            To check, open PowerShell and run:
+          </p>
+          <div className="bg-gray-950 border border-gray-700 rounded-md p-3 font-mono text-xs text-gray-300 overflow-x-auto">
+            <div>Add-Type -AssemblyName System.Windows.Forms</div>
+            <div>[System.Windows.Forms.SystemInformation]::VirtualScreen</div>
+          </div>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Look at the <strong className="text-gray-100">Y</strong> and <strong className="text-gray-100">Height</strong> values. If Y is anything other than 0, or Height is larger than your tallest monitor's vertical resolution, one of your monitors is offset.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display. Carefully drag your monitors so they're perfectly aligned. The snap behavior can sometimes leave a few pixels of offset — zoom in and adjust carefully. Then re-run the PowerShell command to verify.
+          </p>
+          <p className="text-xs text-gray-400 leading-relaxed">
+            If you'd rather not adjust your display arrangement (since it affects cursor movement between screens), just use <strong className="text-gray-300">Tile</strong> mode instead of Span, which bypasses this issue entirely.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="My wallpaper looks slightly zoomed in or shifted">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Check that all your monitors are set to <strong className="text-gray-100">100% scaling</strong>. Open Settings &gt; System &gt; Display, click on each monitor individually, and verify the Scale setting.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            If you need to run a monitor at higher than 100% scaling (common on high-DPI laptops), be aware that Windows may factor this into the span calculation differently. In this case, <strong className="text-gray-100">Tile mode is strongly recommended</strong> over Span.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="How do I verify my wallpaper dimensions are correct?">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Right-click your downloaded wallpaper file &gt; Properties &gt; Details tab. Check the <strong className="text-gray-100">Width</strong> and <strong className="text-gray-100">Height</strong> values.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Your image dimensions match the <strong className="text-gray-100">bounding box</strong> of your Windows arrangement: the smallest rectangle that contains every monitor. Width = horizontal extent (e.g. two 1920×1080 side-by-side → 3840px; stacked vertically → 1920px). Height = vertical extent (e.g. stacked → 2160px). So the image is exactly the size Windows expects for the virtual desktop.
+          </p>
+          <p className="text-xs text-gray-400 leading-relaxed">
+            If these numbers don't match, go back to Spanright and verify your monitor resolutions are entered correctly.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="I want to test if my setup is aligned correctly">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Try creating a simple test wallpaper to diagnose alignment issues:
+          </p>
+          <ol className="text-sm text-gray-300 leading-relaxed list-decimal list-inside space-y-1.5 ml-1">
+            <li>In Spanright, set up your monitor layout as usual.</li>
+            <li>Use a test image with a grid pattern or clearly marked regions — or just use a solid color with distinct colored blocks where each monitor boundary should be.</li>
+            <li>Apply the wallpaper using <strong className="text-gray-100">Tile</strong> mode.</li>
+            <li>Check each monitor: do the boundaries line up exactly at the screen edges? If you see part of the next monitor's section bleeding over, your Windows display arrangement may have a small offset (see the "Virtual Desktop Misalignment" section above).</li>
+          </ol>
+        </AccordionSection>
+
+        <AccordionSection title="The wallpaper sections appear on the wrong monitors">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Spanright's output matches the bounding box of your Windows arrangement (positions and order). Windows applies that same image based on your display arrangement in Settings &gt; Display — so the layout there (left-to-right, top-to-bottom, or mixed) must match what you set in the Virtual Layout tab.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            If these orders don't match, the wallpaper sections will appear on the wrong screens.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display and make sure your monitors are arranged in the same left-to-right order as your Spanright layout. You can drag monitors to reorder them. Click <strong className="text-gray-100">"Identify"</strong> to see which number corresponds to which physical screen.
+          </p>
+        </AccordionSection>
+      </div>
+    </>
+  )
+}
+
+function MacOSContent() {
+  return (
+    <>
+      {/* Priority Tip Callout */}
+      <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-blue-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="text-sm font-semibold text-blue-300">
+            macOS has no native Span mode
+          </h3>
+        </div>
+        <p className="text-sm text-gray-300 leading-relaxed">
+          Unlike Windows, macOS doesn't support setting a single image across all displays. You'll need to crop each monitor's region from the Spanright output and set them individually, or use a third-party wallpaper tool that supports multi-monitor spanning.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <AccordionSection title="How do I find my display arrangement?">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Open <strong className="text-gray-100">System Settings &gt; Displays</strong>, then click <strong className="text-gray-100">Arrange</strong> (or look for the arrangement area showing display rectangles). Drag displays to match your physical layout.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            The arrangement here determines how your cursor moves between screens and how macOS maps coordinates across displays. Replicate this layout in Spanright's Virtual Layout tab.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="Retina / HiDPI displays and resolution">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Retina displays report <strong className="text-gray-100">logical pixels</strong> to most apps (e.g. a Retina MacBook may report as 1440×900 while the actual panel is 2880×1800). When adding monitors in Spanright, use the <strong className="text-gray-100">actual hardware pixel resolution</strong>, not the scaled/logical resolution.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            To find your actual resolution: open <strong className="text-gray-100">System Settings &gt; Displays</strong> and hold <strong className="text-gray-100">Option</strong> while clicking a scaling option to see the native resolution, or check <strong className="text-gray-100">About This Mac &gt; Displays</strong>.
+          </p>
+          <p className="text-xs text-gray-400 leading-relaxed">
+            Using the logical resolution instead of the actual resolution will produce a wallpaper that's too small and appears blurry on Retina screens.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="How do I set the wallpaper from Spanright's output?">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Since macOS sets wallpapers per-display, you'll need to crop the Spanright output for each monitor:
+          </p>
+          <ol className="text-sm text-gray-300 leading-relaxed list-decimal list-inside space-y-1.5 ml-1">
+            <li>Open the downloaded image in <strong className="text-gray-100">Preview</strong> or an image editor.</li>
+            <li>For each monitor, crop the region matching that monitor's position and resolution in the output image.</li>
+            <li>Open <strong className="text-gray-100">System Settings &gt; Wallpaper</strong> (or right-click desktop &gt; Change Wallpaper).</li>
+            <li>Click on each display in the wallpaper settings and assign its cropped image.</li>
+          </ol>
+          <p className="text-xs text-gray-400 leading-relaxed">
+            Third-party tools like <strong className="text-gray-300">Multi Monitor Wallpaper</strong> or <strong className="text-gray-300">Display Maid</strong> can automate this process.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="The wallpaper looks blurry on one or more displays">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            This is usually a Retina resolution mismatch. Make sure your Spanright monitor definitions use the <strong className="text-gray-100">actual hardware pixel resolution</strong>, not the scaled resolution macOS reports. A Retina display at "looks like 1440×900" is actually 2880×1800 — use the latter.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Also check that your source image is large enough — Spanright shows a recommended resolution banner in the toolbar.
+          </p>
+        </AccordionSection>
+      </div>
+    </>
+  )
+}
+
+function LinuxContent() {
+  return (
+    <>
+      {/* Priority Tip Callout */}
+      <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-blue-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <h3 className="text-sm font-semibold text-blue-300">
+            Wallpaper handling varies by desktop environment
+          </h3>
+        </div>
+        <p className="text-sm text-gray-300 leading-relaxed">
+          Linux has no single standard for multi-monitor wallpapers. Some desktop environments (like GNOME) support spanning a single image across displays, while others require per-monitor wallpapers or external tools. The exact steps depend on your DE and display server (X11 vs Wayland).
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <AccordionSection title="How do I find my display arrangement?">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            This depends on your desktop environment:
+          </p>
+          <ul className="text-sm text-gray-300 leading-relaxed list-disc list-inside space-y-1.5 ml-1">
+            <li><strong className="text-gray-100">GNOME:</strong> Open <strong className="text-gray-100">Settings &gt; Displays</strong>. Drag the display rectangles to arrange them.</li>
+            <li><strong className="text-gray-100">KDE Plasma:</strong> Open <strong className="text-gray-100">System Settings &gt; Display and Monitor &gt; Display Configuration</strong>.</li>
+            <li><strong className="text-gray-100">Command line:</strong> Use <code className="text-gray-300 bg-gray-800 px-1 rounded">xrandr --query</code> (X11) or <code className="text-gray-300 bg-gray-800 px-1 rounded">wlr-randr</code> (Wayland/wlroots) to see display positions.</li>
+          </ul>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Replicate the arrangement you see in Spanright's Virtual Layout tab.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="How do I set the wallpaper from Spanright's output?">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Common methods for applying a spanned wallpaper:
+          </p>
+          <ul className="text-sm text-gray-300 leading-relaxed list-disc list-inside space-y-1.5 ml-1">
+            <li><strong className="text-gray-100">GNOME:</strong> Use <code className="text-gray-300 bg-gray-800 px-1 rounded">gsettings set org.gnome.desktop.background picture-options 'spanned'</code> then set the image URI. Or use <strong className="text-gray-100">Settings &gt; Background</strong> and choose the image — GNOME 42+ supports "Span" in the background settings.</li>
+            <li><strong className="text-gray-100">KDE Plasma:</strong> Right-click the desktop &gt; Configure Desktop &gt; Wallpaper. Some versions support spanning; you may need to set each monitor's portion individually.</li>
+            <li><strong className="text-gray-100">feh (X11):</strong> <code className="text-gray-300 bg-gray-800 px-1 rounded">feh --bg-scale /path/to/wallpaper.png</code> will scale across your combined display area.</li>
+            <li><strong className="text-gray-100">nitrogen (X11):</strong> Select the image and choose "Scaled" or "Zoomed" fitting.</li>
+            <li><strong className="text-gray-100">swaybg (Wayland/Sway):</strong> <code className="text-gray-300 bg-gray-800 px-1 rounded">swaybg -i /path/to/wallpaper.png -m fill</code></li>
+            <li><strong className="text-gray-100">Hyprpaper (Hyprland):</strong> Configure in <code className="text-gray-300 bg-gray-800 px-1 rounded">~/.config/hypr/hyprpaper.conf</code></li>
+          </ul>
+          <p className="text-xs text-gray-400 leading-relaxed">
+            If your tool doesn't support spanning, crop per-monitor regions from the output (similar to the macOS approach) and set each monitor individually.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="HiDPI / fractional scaling issues">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            If you use fractional scaling (e.g. 150% or 200%), your desktop environment may report a logical resolution that differs from the panel's native resolution. When adding monitors in Spanright, use the <strong className="text-gray-100">native hardware resolution</strong>.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            You can check your actual resolution with <code className="text-gray-300 bg-gray-800 px-1 rounded">xrandr --query</code> (look for the active mode, e.g. <code className="text-gray-300 bg-gray-800 px-1 rounded">2560x1440+0+0</code>) or <code className="text-gray-300 bg-gray-800 px-1 rounded">wlr-randr</code> on Wayland.
+          </p>
+        </AccordionSection>
+
+        <AccordionSection title="The wallpaper doesn't align across monitors">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Verify that your Spanright Virtual Layout matches what your display server reports. On X11, run <code className="text-gray-300 bg-gray-800 px-1 rounded">xrandr --query</code> and check the position offsets (e.g. <code className="text-gray-300 bg-gray-800 px-1 rounded">2560x1440+1920+0</code> means the display is at x=1920, y=0).
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            Some wallpaper tools scale the image differently. Try different fit modes ("fill", "scale", "span") or switch tools to see which produces correct alignment.
+          </p>
+        </AccordionSection>
+      </div>
+    </>
+  )
+}
+
 export default function TroubleshootingGuide({ onClose }: TroubleshootingGuideProps) {
+  const [platform, setPlatform] = useState<Platform>('windows')
+
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto">
       {/* Backdrop */}
@@ -62,100 +324,13 @@ export default function TroubleshootingGuide({ onClose }: TroubleshootingGuidePr
             </p>
           </div>
 
-          {/* Priority Tip Callout */}
-          <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 space-y-2">
-            <div className="flex items-center gap-2">
-              <svg className="w-5 h-5 text-blue-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <h3 className="text-sm font-semibold text-blue-300">
-                If Span isn't working, try Tile
-              </h3>
-            </div>
-            <p className="text-sm text-gray-300 leading-relaxed">
-              Your wallpaper is designed for Windows <strong className="text-blue-300">Span</strong> mode, and that should work perfectly in most setups. But if you're seeing stretching, bleed, or misalignment, try switching to <strong className="text-blue-300">Tile</strong> instead: right-click your desktop &gt; Personalize &gt; Background, and change the fit mode.
-            </p>
-            <p className="text-xs text-gray-400 leading-relaxed">
-              <strong className="text-gray-300">Why does this help?</strong> Span mode scales your image to fit the Windows virtual desktop bounding box — the exterior rectangle that contains your entire display setup (side-by-side, stacked vertical, or mixed). If any monitor is even a few pixels offset, Windows will stretch the image to compensate, causing visible bleed. Tile mode places the image at exact 1:1 pixel scale with no resizing, bypassing the issue entirely.
-            </p>
-          </div>
+          {/* Platform Tabs */}
+          <PlatformTabs active={platform} onChange={setPlatform} />
 
-          {/* Accordion Sections */}
-          <div className="space-y-2">
-
-            {/* Section: Virtual Desktop Misalignment */}
-            <AccordionSection title="I see a few pixels of overflow/bleed between monitors">
-              <p className="text-sm text-gray-300 leading-relaxed">
-                This usually means your Windows display arrangement has a small vertical offset. Even a few pixels will cause Windows to scale your wallpaper.
-              </p>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                To check, open PowerShell and run:
-              </p>
-              <div className="bg-gray-950 border border-gray-700 rounded-md p-3 font-mono text-xs text-gray-300 overflow-x-auto">
-                <div>Add-Type -AssemblyName System.Windows.Forms</div>
-                <div>[System.Windows.Forms.SystemInformation]::VirtualScreen</div>
-              </div>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                Look at the <strong className="text-gray-100">Y</strong> and <strong className="text-gray-100">Height</strong> values. If Y is anything other than 0, or Height is larger than your tallest monitor's vertical resolution, one of your monitors is offset.
-              </p>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display. Carefully drag your monitors so they're perfectly aligned. The snap behavior can sometimes leave a few pixels of offset — zoom in and adjust carefully. Then re-run the PowerShell command to verify.
-              </p>
-              <p className="text-xs text-gray-400 leading-relaxed">
-                If you'd rather not adjust your display arrangement (since it affects cursor movement between screens), just use <strong className="text-gray-300">Tile</strong> mode instead of Span, which bypasses this issue entirely.
-              </p>
-            </AccordionSection>
-
-            {/* Section: Display Scaling */}
-            <AccordionSection title="My wallpaper looks slightly zoomed in or shifted">
-              <p className="text-sm text-gray-300 leading-relaxed">
-                Check that all your monitors are set to <strong className="text-gray-100">100% scaling</strong>. Open Settings &gt; System &gt; Display, click on each monitor individually, and verify the Scale setting.
-              </p>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                If you need to run a monitor at higher than 100% scaling (common on high-DPI laptops), be aware that Windows may factor this into the span calculation differently. In this case, <strong className="text-gray-100">Tile mode is strongly recommended</strong> over Span.
-              </p>
-            </AccordionSection>
-
-            {/* Section: Verifying Output */}
-            <AccordionSection title="How do I verify my wallpaper dimensions are correct?">
-              <p className="text-sm text-gray-300 leading-relaxed">
-                Right-click your downloaded wallpaper file &gt; Properties &gt; Details tab. Check the <strong className="text-gray-100">Width</strong> and <strong className="text-gray-100">Height</strong> values.
-              </p>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                Your image dimensions match the <strong className="text-gray-100">bounding box</strong> of your Windows arrangement: the smallest rectangle that contains every monitor. Width = horizontal extent (e.g. two 1920×1080 side-by-side → 3840px; stacked vertically → 1920px). Height = vertical extent (e.g. stacked → 2160px). So the image is exactly the size Windows expects for the virtual desktop.
-              </p>
-              <p className="text-xs text-gray-400 leading-relaxed">
-                If these numbers don't match, go back to Spanright and verify your monitor resolutions are entered correctly.
-              </p>
-            </AccordionSection>
-
-            {/* Section: Diagnostic Test */}
-            <AccordionSection title="I want to test if my setup is aligned correctly">
-              <p className="text-sm text-gray-300 leading-relaxed">
-                Try creating a simple test wallpaper to diagnose alignment issues:
-              </p>
-              <ol className="text-sm text-gray-300 leading-relaxed list-decimal list-inside space-y-1.5 ml-1">
-                <li>In Spanright, set up your monitor layout as usual.</li>
-                <li>Use a test image with a grid pattern or clearly marked regions — or just use a solid color with distinct colored blocks where each monitor boundary should be.</li>
-                <li>Apply the wallpaper using <strong className="text-gray-100">Tile</strong> mode.</li>
-                <li>Check each monitor: do the boundaries line up exactly at the screen edges? If you see part of the next monitor's section bleeding over, your Windows display arrangement may have a small offset (see the "Virtual Desktop Misalignment" section above).</li>
-              </ol>
-            </AccordionSection>
-
-            {/* Section: Monitor Order Mismatch */}
-            <AccordionSection title="The wallpaper sections appear on the wrong monitors">
-              <p className="text-sm text-gray-300 leading-relaxed">
-                Spanright’s output matches the bounding box of your Windows arrangement (positions and order). Windows applies that same image based on your display arrangement in Settings &gt; Display — so the layout there (left-to-right, top-to-bottom, or mixed) must match what you set in the Windows Arrangement tab.
-              </p>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                If these orders don't match, the wallpaper sections will appear on the wrong screens.
-              </p>
-              <p className="text-sm text-gray-300 leading-relaxed">
-                <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display and make sure your monitors are arranged in the same left-to-right order as your Spanright layout. You can drag monitors to reorder them. Click <strong className="text-gray-100">"Identify"</strong> to see which number corresponds to which physical screen.
-              </p>
-            </AccordionSection>
-
-          </div>
+          {/* Platform-specific content */}
+          {platform === 'windows' && <WindowsContent />}
+          {platform === 'macos' && <MacOSContent />}
+          {platform === 'linux' && <LinuxContent />}
 
           {/* Footer */}
           <button


### PR DESCRIPTION
## Summary

- **Cross-platform support**: Extended all user-facing instructions and UI text to cover macOS and Linux alongside the existing Windows content. README now includes platform-specific sections for display arrangement and wallpaper setup (macOS per-monitor crop workflow, Linux DE-specific tools like feh/swaybg/gsettings). Added a Platform Support comparison table.
- **TroubleshootingGuide platform tabs**: Added a Windows / macOS / Linux tab selector. Windows tab retains all existing content unchanged. macOS tab covers Retina/HiDPI resolution caveats, per-monitor crop workflow, and blurriness troubleshooting. Linux tab covers DE-specific display settings (GNOME, KDE, xrandr, wlr-randr), wallpaper tools, and HiDPI/fractional scaling.
- **InfoDialog made platform-neutral**: Title changed from "How Windows Span Mode Works" to "How Spanright Generates Your Wallpaper." Steps generalized to reference "your OS" instead of Windows. "How to check your display arrangement" section now has Windows, macOS, and Linux subsections.
- **"Windows Arrangement" renamed to "Virtual Layout"**: Tab label, welcome dialog, checkbox, help text, warning banners, and all user-facing references updated. Pairs cleanly with "Physical Layout" and avoids conflation with the physical display concept. Internal code identifiers (`ActiveTab`, `windowsArrangement`, etc.) are unchanged.
- **Horizontal alignment check added**: The Virtual Layout tab previously only warned about vertical alignment mismatches between physical and virtual layouts. Now also detects horizontal mismatches, with a dynamic message specifying which axis (vertical, horizontal, or both) differs.

Closes #28 