### PR TITLE
Clear up sections of info and help

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Toolbar from './components/Toolbar'
 import PreviewPanel from './components/PreviewPanel'
 import WindowsArrangementCanvas from './components/WindowsArrangementCanvas'
 import TroubleshootingGuide from './components/TroubleshootingGuide'
+import InfoDialog from './components/InfoDialog'
 import type { ActiveTab } from './types'
 
 function TabButton({ tab, label, active, onClick }: { tab: ActiveTab; label: string; active: boolean; onClick: (tab: ActiveTab) => void }) {
@@ -179,18 +180,29 @@ function AppContent() {
             Spanright
           </h1>
         </a>
-        <span className="text-xs text-gray-500 flex-1">
+        <span className="text-xs text-gray-500">
           Multi-Monitor Wallpaper Alignment Tool
         </span>
         <button
           onClick={() => setShowWelcome(true)}
           className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
-          title="How to Use"
+          title="Quick Start"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
           </svg>
-          <span className="text-xs">How to Use</span>
+          <span className="text-xs">Quick Start</span>
+        </button>
+        <div className="flex-1" />
+        <button
+          onClick={() => dispatch({ type: 'SET_SHOW_HOW_IT_WORKS', value: true })}
+          className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
+          title="How It Works"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+          </svg>
+          <span className="text-xs">How It Works</span>
         </button>
         <button
           onClick={() => dispatch({ type: 'SET_SHOW_TROUBLESHOOTING_GUIDE', value: true })}
@@ -245,6 +257,11 @@ function AppContent() {
         </div>
       )}
 
+      {/* How It Works Modal */}
+      {state.showHowItWorks && (
+        <InfoDialog onClose={() => dispatch({ type: 'SET_SHOW_HOW_IT_WORKS', value: false })} />
+      )}
+
       {/* Troubleshooting Guide Modal */}
       {state.showTroubleshootingGuide && (
         <TroubleshootingGuide onClose={() => dispatch({ type: 'SET_SHOW_TROUBLESHOOTING_GUIDE', value: false })} />
@@ -253,7 +270,7 @@ function AppContent() {
       {/* About Modal */}
       {showAbout && <AboutDialog onClose={() => setShowAbout(false)} />}
 
-      {/* Welcome / How to Use Modal */}
+      {/* Welcome / Quick Start Modal */}
       {showWelcome && <WelcomeDialog onClose={() => setShowWelcome(false)} />}
     </div>
   )

--- a/src/components/InfoDialog.tsx
+++ b/src/components/InfoDialog.tsx
@@ -155,6 +155,10 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
             </div>
           </div>
 
+          <p className="text-[11px] text-gray-500 text-center">
+            Having trouble with your wallpaper? Check the <strong className="text-gray-400">Troubleshooting</strong> guide in the header bar.
+          </p>
+
           {/* Close button */}
           <button
             onClick={onClose}

--- a/src/components/WindowsArrangementCanvas.tsx
+++ b/src/components/WindowsArrangementCanvas.tsx
@@ -2,7 +2,6 @@ import { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import { useStore } from '../store'
 import type { Monitor } from '../types'
 import { getMonitorDisplayName } from '../utils'
-import InfoDialog from './InfoDialog'
 
 const MONITOR_COLORS = [
   '#3b82f6', '#8b5cf6', '#06b6d4', '#10b981',
@@ -130,7 +129,6 @@ export default function WindowsArrangementCanvas() {
   const [dimensions, setDimensions] = useState({ width: 800, height: 500 })
   const [dragging, setDragging] = useState<string | null>(null)
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
-  const [showInfoDialog, setShowInfoDialog] = useState(false)
   const [frozenLayout, setFrozenLayout] = useState<{ displayScale: number; offsetX: number; offsetY: number } | null>(null)
 
   // Resize observer
@@ -448,17 +446,6 @@ export default function WindowsArrangementCanvas() {
           </>
         )}
 
-        <div className="flex-1" />
-
-        <button
-          onClick={() => setShowInfoDialog(true)}
-          className="text-xs text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-1"
-        >
-          <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
-            <path fillRule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm6.5-.25A.75.75 0 017.25 7h1a.75.75 0 01.75.75v2.75h.25a.75.75 0 010 1.5h-2a.75.75 0 010-1.5h.25v-2h-.25a.75.75 0 01-.75-.75zM8 6a1 1 0 100-2 1 1 0 000 2z" />
-          </svg>
-          How does this work?
-        </button>
       </div>
 
       {/* Baseline warning when customizing — in flow so it’s always visible */}
@@ -468,7 +455,7 @@ export default function WindowsArrangementCanvas() {
             <strong>Note:</strong> Changing your OS display settings (position, order, resolution) can get messy.
             For best results, align monitor edges (e.g. top-aligned side-by-side, or stacked vertically with left/right edges aligned).
             Black bars are normal in some setups, but misaligned arrangements may produce visible black bars in the spanned wallpaper.
-            For more info, see “How does this work?” in the top bar.
+            {' '}<button onClick={() => dispatch({ type: 'SET_SHOW_HOW_IT_WORKS', value: true })} className="text-amber-300 underline underline-offset-2 hover:text-amber-100 transition-colors">Learn more</button>
           </p>
         </div>
       )}
@@ -520,8 +507,6 @@ export default function WindowsArrangementCanvas() {
         )}
       </div>
 
-      {/* Info dialog */}
-      {showInfoDialog && <InfoDialog onClose={() => setShowInfoDialog(false)} />}
     </div>
   )
 }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -18,6 +18,7 @@ interface State {
   useWindowsArrangement: boolean
   activeTab: ActiveTab
   showTroubleshootingGuide: boolean
+  showHowItWorks: boolean
 }
 
 type Action =
@@ -46,6 +47,7 @@ type Action =
   | { type: 'MOVE_WINDOWS_MONITOR'; monitorId: string; pixelX: number; pixelY: number }
   | { type: 'SYNC_WINDOWS_ARRANGEMENT' }
   | { type: 'SET_SHOW_TROUBLESHOOTING_GUIDE'; value: boolean }
+  | { type: 'SET_SHOW_HOW_IT_WORKS'; value: boolean }
 
 const initialState: State = {
   monitors: [],
@@ -62,6 +64,7 @@ const initialState: State = {
   useWindowsArrangement: false,
   activeTab: 'physical',
   showTroubleshootingGuide: false,
+  showHowItWorks: false,
 }
 
 /** Strip width in pixels for output (depends on rotation). */
@@ -236,6 +239,8 @@ function reducer(state: State, action: Action): State {
       }
     case 'SET_SHOW_TROUBLESHOOTING_GUIDE':
       return { ...state, showTroubleshootingGuide: action.value }
+    case 'SET_SHOW_HOW_IT_WORKS':
+      return { ...state, showHowItWorks: action.value }
     default:
       return state
   }


### PR DESCRIPTION
## Summary

- **Header reorganized**: "How to Use" renamed to "Quick Start" and moved to the left side of the header (onboarding zone). New "How It Works" button added to the right side (reference tools zone) that opens the InfoDialog globally.
- **InfoDialog promoted to header level**: Removed the "How does this work?" button from the Virtual Layout tab bar. The inline warning banner now has a "Learn more" link that opens the same dialog via global state. Added a Troubleshooting cross-reference note at the bottom of the dialog.