### PR TITLE
Undo/redo support for canvas actions

### DIFF
--- a/src/components/ConfigManager.tsx
+++ b/src/components/ConfigManager.tsx
@@ -79,10 +79,7 @@ export default function ConfigManager() {
   }
 
   const handleLoad = (config: SavedConfig) => {
-    dispatch({ type: 'CLEAR_ALL_MONITORS' })
-    for (const m of config.monitors) {
-      dispatch({ type: 'ADD_MONITOR', preset: m.preset, x: m.physicalX, y: m.physicalY, rotation: m.rotation ?? 0, displayName: m.displayName })
-    }
+    dispatch({ type: 'LOAD_LAYOUT', monitors: config.monitors })
     toast.success(`Layout loaded: ${config.name}`)
     setOpen(false)
   }


### PR DESCRIPTION
## Summary
- Add an undo/redo system that captures canvas state after each meaningful action, with smart batching for continuous operations like dragging
- History stack wraps the existing reducer automatically — components don't need to manually push snapshots
- Undo/redo buttons placed in the canvas overlay next to the kebab menu, with Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y keyboard shortcuts
- Integrated with the toast notification system for feedback ("Undo: Move monitor", "Redo: Add monitor", etc.)

### Architecture
- `undoableReducer` wraps the existing reducer in `store.tsx`, intercepting actions and managing a 50-entry history stack
- **Discrete actions** (add/remove/rotate monitor, clear all, load image, remove image, rename, load layout, resize image) always push a snapshot before executing
- **Continuous actions** (drag monitor, drag image, scale image) only push on the *first* dispatch of a drag sequence — subsequent frames during the same drag are batched, so undo reverts to the pre-drag position in one step
- Non-undoable actions (zoom, pan, tab switch, toggles) reset the continuous batch key so the next drag creates a fresh entry
- New action after undo clears the redo stack (standard behavior)

### New composite actions
- `LOAD_LAYOUT` — replaces the old CLEAR_ALL_MONITORS + multiple ADD_MONITOR pattern so loading a saved layout is a single undo entry
- `SET_IMAGE_TRANSFORM` — combines position + size into one atomic action, used for both "Size image to fit" and image resize-end so undo correctly reverts both coordinates and dimensions together

### Files changed
- `src/store.tsx` — undo/redo stack, `undoableReducer` wrapper, `UndoableSnapshot` type, discrete/continuous action classification, `LOAD_LAYOUT` and `SET_IMAGE_TRANSFORM` actions, extended context with `canUndo`/`canRedo`/`undoLabel`/`redoLabel`
- `src/components/EditorCanvas.tsx` — undo/redo buttons in canvas overlay next to kebab menu, Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y keyboard shortcuts with case-insensitive key matching, `SET_IMAGE_TRANSFORM` for image resize-end and size-to-fit, toast integration
- `src/components/Toolbar.tsx` — removed undo/redo buttons (moved to canvas overlay)
- `src/components/ConfigManager.tsx` — uses `LOAD_LAYOUT` composite action instead of multiple dispatches

## Test plan
- [ ] Add a monitor → undo → monitor disappears → redo → monitor reappears
- [ ] Drag a monitor → undo → reverts to pre-drag position (not intermediate)
- [ ] Delete a monitor → undo → monitor restored
- [ ] Rotate a monitor → undo → rotation reverted
- [ ] Upload an image → undo → image removed → redo → image reappears (no re-upload needed)
- [ ] Resize image via corner handles → undo → both position and size revert correctly
- [ ] "Size image to fit" → undo → image reverts to previous position and size in one step
- [ ] Load a saved layout → undo → previous layout fully restored in one step
- [ ] Clear all monitors → undo → all monitors restored
- [ ] Ctrl+Z undoes, Ctrl+Shift+Z redoes, Ctrl+Y redoes
- [ ] Perform action after undo → redo stack is cleared
- [ ] Buttons disabled (grayed out) when nothing to undo/redo
- [ ] Toast shows action label: "Undo: Move monitor", "Redo: Add monitor", etc.
- [ ] Rapid actions don't exceed 50 history entries