### PR TITLE
Lots of small upgrades to codebase, UI/copy tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Spanright operates in **physical space** (inches/cm), so you arrange monitors as
 - **Drag-and-drop presets** — Choose from 18+ built-in monitor presets (laptops, standard monitors, ultrawides, super ultrawides) and drag them directly onto the canvas.
 - **Custom monitors** — Define any monitor by diagonal size, aspect ratio, and resolution. Supports fully custom resolution entry or filtered presets by aspect ratio. Diagonal is limited to 5"–120"; aspect ratio is limited to 10:1 or less (no ultra-thin "line" monitors). Validation warnings appear when limits are exceeded; Add is disabled until fixed.
 - **Monitor rotation** — Rotate any monitor 90° (portrait/landscape) via the ↻ button or **right-click** context menu. Resolution is swapped (e.g. 1080×1920 when rotated); rotation is saved in saved layouts and reflected in output and the Virtual Layout view.
-- **Right-click context menu** — Right-click any monitor for **Set Bezels**, **Rename**, **Rotate 90°**, and **Delete**. Bezels are optional per-edge borders (in mm) that extend outward from the display area; they help with alignment and matching real bezels, and Align Assist snaps to outer bezel edges when set.
+- **Right-click or kebab menu** — Right-click any monitor, or when a monitor is selected click the **⋮** (kebab) button next to the **✕** delete button, for **Set Bezels**, **Rename**, **Rotate 90°**, and **Delete**. Bezels are optional per-edge borders (in mm) that extend outward from the display area; they help with alignment and matching real bezels, and Align Assist snaps to outer bezel edges when set.
 - **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display. Vertical images (height > width) default to 6 ft tall; horizontal ones default to 6 ft wide.
 - **Smart image recommendations** — Calculates the minimum source image resolution needed based on your layout's physical size and the highest-PPI monitor.
 - **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's virtual layout position (side-by-side, stacked, or mixed). Fills any gaps in the layout with black.
 - **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
 - **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom (up to 400%), right-click drag to pan. Custom scrollbars, Align Assist guides/snapping, and fit-to-view.
-- **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, bezels, virtual layout). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Basic but very useful for multi-setup workflows.
+- **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, bezels, virtual layout). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Optional **Quick layouts** (preloaded in code) appear at the top of the Saved Layouts dropdown when configured. The Saved Layouts control sits on the right side of the toolbar, to the left of Share Layout.
 - **Cross-platform** — Works in any modern browser. Output can be applied as a spanned wallpaper on Windows (Span/Tile mode), macOS (per-monitor crop), and Linux (varies by DE — GNOME, KDE, feh, swaybg, etc.).
 
 ## Example
@@ -36,7 +36,7 @@ Dragon image [source](https://unsplash.com/photos/dragon-effigy-breathes-fire-ov
 <img width="1920" height="1039" alt="dragonfire-preview" src="https://github.com/user-attachments/assets/fb335e52-bd18-4b3f-9083-f53ad9e047cc" />
 
 ### Result
-Spanright's output wallpaper (6400x1080) displayed on a 14" 1080p laptop, a 24" 1080p monitor, and 34" 2560x1080 ultrawide monitor. The total resolution of this setup is (1920 + 1920 + 2560) x (1080) = 6400x1080. And the the total aspect ratio of this setup would be (16 + 16 + 21) / (9) = 53:9. The image will only look good when Spanright modifies the image to take account of the physical monitor dimensions and spacing as well. Even though the preview looks disjointed, it actually alignes perfectly when used as the wallpaper.
+Spanright's output wallpaper (6400x1080) displayed on a 14" 1080p laptop, a 24" 1080p monitor, and 34" 2560x1080 ultrawide monitor. The total resolution of this setup is (1920 + 1920 + 2560) x (1080) = 6400x1080. And the total aspect ratio of this setup would be (16 + 16 + 21) / (9) = 53:9. The image will only look good when Spanright modifies the image to take account of the physical monitor dimensions and spacing as well. Even though the preview looks disjointed, it actually aligns perfectly when used as the wallpaper.
 
 Standard 53:9 crop of dragon picture:
 ![dragonfire-lazy-53-9](https://github.com/user-attachments/assets/a4d9ee67-5bb5-4a6d-9987-703bf339b208)
@@ -63,12 +63,13 @@ Drag monitors on the canvas to match your physical desk arrangement:
 
 - Position your laptop screen lower-left, your main monitor centered, etc.
 - The canvas uses physical dimensions — a 27" monitor will appear larger than a 13" laptop
-- **Right-click** a monitor for the context menu: **Set Bezels** (optional per-edge borders in mm for alignment and real-world bezel compensation), **Rename**, **Rotate 90°**, or **Delete**. Bezels extend outward from the display area; Align Assist snaps to outer bezel edges when bezels are set.
+- **Right-click** a monitor, or select it and click the **⋮** kebab next to the **✕**, for the context menu: **Set Bezels**, **Rename**, **Rotate 90°**, or **Delete**. Bezels extend outward from the display area; Align Assist snaps to outer bezel edges when bezels are set.
+- When the **source image** is selected, use the **⋮** kebab (next to **✕**) for **Size image to fit** or **Remove image**.
 - Use **Align Assist** (canvas menu) for dynamic edge/center alignment guides while dragging monitors
 - Use the **↻** (rotate) button on a monitor, or **Rotate 90°** from the right-click menu, to switch between landscape and portrait
 - Click a monitor and press **Delete** (or use the context menu) to remove it
 - Press **F** to fit all monitors in view
-- Use **Saved Layouts** in the toolbar to save or load monitor layouts (e.g. desk vs laptop-only); layouts are stored in your browser and include bezel settings
+- Use **Saved Layouts** (right side of toolbar, left of Share Layout) to save or load monitor layouts; layouts are stored in your browser and include bezel settings. Quick layouts can be preloaded in `src/preloadedLayouts.ts`.
 
 ### 3. Upload & Position Your Image
 
@@ -76,7 +77,7 @@ Drag monitors on the canvas to match your physical desk arrangement:
 - The image appears behind the monitors with 70% opacity
 - **Drag** the image to reposition it
 - **Click** the image and use the corner handles to resize it
-- Use **Size image to fit** (canvas menu) to automatically cover your monitor layout bounding box while preserving aspect ratio (overflow is centered)
+- Use **Size image to fit** from the canvas menu (top-right ⋮) or from the **⋮** kebab on the source image when selected
 - With **Align Assist** enabled, image drag/resize shows green alignment guides against monitor edges/centers
 - Check the **recommended image size** banner in the toolbar — green means your image is large enough, yellow/red means it may appear pixelated
 
@@ -153,7 +154,7 @@ Linux wallpaper handling varies by desktop environment:
 | Zoom | Ctrl + Scroll (up to 400%) |
 | Fit view | Press **F** / click **Fit** button |
 | Select monitor | Click on it |
-| Monitor context menu | **Right-click** monitor → Set Bezels, Rename, Rotate 90°, Delete |
+| Monitor context menu | **Right-click** monitor or select + **⋮** kebab → Set Bezels, Rename, Rotate 90°, Delete |
 | Delete monitor | Select + **Delete** or **Backspace**, or right-click → Delete |
 | Deselect | **Escape** or click empty space |
 
@@ -207,6 +208,10 @@ src/
 ├── types.ts                   # TypeScript interfaces
 ├── utils.ts                   # PPI calculations, coordinate math
 ├── presets.ts                 # Monitor preset definitions
+├── canvasConstants.ts         # Canvas bounds (inches) and center for preloaded layouts
+├── urlLayout.ts               # Encode/decode layout for share URL
+├── preloadedLayouts.ts       # Optional quick-layout presets (centered at canvas center)
+├── icons.tsx                  # Shared SVG icon components
 ├── generateOutput.ts          # Wallpaper stitching logic
 ├── index.css                  # Tailwind imports
 └── components/
@@ -216,9 +221,13 @@ src/
     ├── Toolbar.tsx                 # Top toolbar controls
     ├── PreviewPanel.tsx            # Output preview + download
     ├── ImageUpload.tsx             # File upload component
-    ├── ConfigManager.tsx            # Saved layouts (save/load)
+    ├── ConfigManager.tsx            # Saved layouts + quick layouts (save/load)
+    ├── ShareButton.tsx             # Copy share link to clipboard
     ├── InfoDialog.tsx              # App info / keyboard shortcuts
     └── TroubleshootingGuide.tsx     # Wallpaper troubleshooting
+
+scripts/
+└── center-preloaded-layouts.mjs   # Dev script: center layout strings at canvas center (run when adding preloaded layouts)
 ```
 
 ## Running locally

--- a/scripts/center-preloaded-layouts.mjs
+++ b/scripts/center-preloaded-layouts.mjs
@@ -1,0 +1,108 @@
+/**
+ * One-off dev script: decode preloaded layout strings, center each at canvas center, re-encode.
+ *
+ * Why a standalone .mjs script instead of .ts/.tsx?
+ * - This is a CLI tool you run when adding/updating preloaded layouts, not part of the app.
+ * - The app is a browser bundle (Vite/React); this runs in Node. Plain .mjs runs with
+ *   `node scripts/center-preloaded-layouts.mjs` with no build or ts-node.
+ * - Logic is inlined (decode, encode, PPI) so the script has no project imports.
+ *
+ * Target center must match src/canvasConstants.ts: CANVAS_CENTER_X_IN, CANVAS_CENTER_Y_IN.
+ * Run: node scripts/center-preloaded-layouts.mjs
+ * Then paste the printed encoded strings into src/preloadedLayouts.ts
+ */
+const TARGET_CENTER_X = 72  // must match CANVAS_CENTER_X_IN in src/canvasConstants.ts
+const TARGET_CENTER_Y = 48  // must match CANVAS_CENTER_Y_IN in src/canvasConstants.ts
+
+function toUrlBase64(str) {
+  return Buffer.from(str, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+function fromUrlBase64(str) {
+  let b64 = str.replace(/-/g, '+').replace(/_/g, '/')
+  while (b64.length % 4 !== 0) b64 += '='
+  return Buffer.from(b64, 'base64').toString('utf8')
+}
+
+function calculatePPI(resX, resY, diagonal) {
+  return Math.sqrt(resX * resX + resY * resY) / diagonal
+}
+function physicalDimensions(resX, resY, ppi) {
+  return { width: resX / ppi, height: resY / ppi }
+}
+
+const ENCODED = [
+  'eyJ2IjoxLCJtIjpbeyJuIjoiMTUuNlwiIExhcHRvcCBGSEQiLCJkIjoxNS42LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjQ0LjA5OTcsInkiOjMxLjQzODYsImJ6IjpbOCwxOCw1LDVdfSx7Im4iOiIyNFwiIEZIRCIsImQiOjI0LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjU4LjIwODEsInkiOjE4LjU2MjYsInJvdCI6OTAsImJ6IjpbOCw4LDgsOF19XX0',
+  'eyJ2IjoxLCJtIjpbeyJuIjoiMTUuNlwiIExhcHRvcCBGSEQiLCJkIjoxNS42LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjQ0LjA5OTcsInkiOjQwLjExMDMsImJ6IjpbOCwxOCw1LDVdfSx7Im4iOiIyNFwiIEZIRCIsImQiOjI0LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjU4LjIwODEsInkiOjI3LjcxNDEsImJ6IjpbOCw4LDgsOF19LHsibiI6IjI0XCIgRkhEIiwiZCI6MjQsImFyIjpbMTYsOV0sInJ4IjoxOTIwLCJyeSI6MTA4MCwieCI6NzkuNzU1OCwieSI6MjcuNzE0MSwiYnoiOls4LDgsOCw4XX1dfQ',
+  'eyJ2IjoxLCJtIjpbeyJuIjoiMjRcIiBGSEQiLCJkIjoyNCwiYXIiOlsxNiw5XSwicngiOjE5MjAsInJ5IjoxMDgwLCJ4Ijo3MS4zMTY4LCJ5IjoxMi4wNTkyLCJyb3QiOjkwLCJieiI6WzgsOCw4LDhdfSx7Im4iOiIyN1wiIEZIRCIsImQiOjI3LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjQ3LjE1NDMsInkiOjE5Ljc0LCJieiI6WzgsOCw4LDhdfSx7Im4iOiIyNFwiIEZIRCIsImQiOjI0LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjM0Ljc1ODEsInkiOjEyLjA1OTIsInJvdCI6OTAsImJ6IjpbOCw4LDgsOF19XX0',
+]
+
+function decode(encoded) {
+  const json = fromUrlBase64(encoded)
+  const layout = JSON.parse(json)
+  if (!layout || layout.v !== 1 || !Array.isArray(layout.m)) return null
+  return layout.m
+}
+
+function encode(monitors) {
+  const m = monitors.map(mon => {
+    const entry = {
+      n: mon.n,
+      d: mon.d,
+      ar: mon.ar,
+      rx: mon.rx,
+      ry: mon.ry,
+      x: Math.round(mon.x * 10000) / 10000,
+      y: Math.round(mon.y * 10000) / 10000,
+    }
+    if (mon.rot === 90) entry.rot = 90
+    if (mon.dn) entry.dn = mon.dn
+    if (mon.bz && (mon.bz[0] || mon.bz[1] || mon.bz[2] || mon.bz[3])) entry.bz = mon.bz
+    return entry
+  })
+  return toUrlBase64(JSON.stringify({ v: 1, m }))
+}
+
+function centerLayout(monitors) {
+  if (monitors.length === 0) return monitors
+  const withDims = monitors.map(mon => {
+    const ppi = calculatePPI(mon.rx, mon.ry, mon.d)
+    let { width, height } = physicalDimensions(mon.rx, mon.ry, ppi)
+    if (mon.rot === 90) [width, height] = [height, width]
+    return { ...mon, width, height }
+  })
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const m of withDims) {
+    minX = Math.min(minX, m.x)
+    minY = Math.min(minY, m.y)
+    maxX = Math.max(maxX, m.x + m.width)
+    maxY = Math.max(maxY, m.y + m.height)
+  }
+  const layoutCenterX = (minX + maxX) / 2
+  const layoutCenterY = (minY + maxY) / 2
+  const shiftX = TARGET_CENTER_X - layoutCenterX
+  const shiftY = TARGET_CENTER_Y - layoutCenterY
+  return withDims.map(({ width, height, ...rest }) => ({
+    ...rest,
+    x: rest.x + shiftX,
+    y: rest.y + shiftY,
+  }))
+}
+
+const names = [
+  '15.6" Laptop + Vertical 24" Monitor',
+  '15.6" Laptop + 2 24" Monitors',
+  '27" + 2 24" Vertical Monitors',
+]
+
+console.log(`// Centered at canvas center (${TARGET_CENTER_X}, ${TARGET_CENTER_Y}) in. Paste into PRELOADED_LAYOUTS in src/preloadedLayouts.ts:\n`)
+for (let i = 0; i < ENCODED.length; i++) {
+  const raw = decode(ENCODED[i])
+  if (!raw) {
+    console.log(`// ${names[i]}: decode failed\n`)
+    continue
+  }
+  const centered = centerLayout(raw)
+  const encoded = encode(centered)
+  console.log(`  { name: '${names[i]}', encoded: '${encoded}' },`)
+}
+console.log('')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import InfoDialog from './components/InfoDialog'
 import { ToastProvider } from './components/Toast'
 import type { ActiveTab } from './types'
 import { getLayoutFromHash, clearLayoutHash } from './urlLayout'
+import { IconClose, IconBook, IconLightbulb, IconInfoCircle } from './icons'
 
 function TabButton({ tab, label, active, onClick }: { tab: ActiveTab; label: string; active: boolean; onClick: (tab: ActiveTab) => void }) {
   return (
@@ -38,9 +39,7 @@ function AboutDialog({ onClose }: { onClose: () => void }) {
           onClick={onClose}
           className="absolute top-3 right-3 text-gray-500 hover:text-gray-300 transition-colors"
         >
-          <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
+          <IconClose className="w-5 h-5" />
         </button>
         <div className="p-6 text-center space-y-3">
           <img src="/spanright-logo-large.png" alt="Spanright" className="h-10 w-auto mx-auto" />
@@ -98,9 +97,7 @@ function WelcomeDialog({ onClose }: { onClose: () => void }) {
           onClick={handleClose}
           className="absolute top-3 right-3 text-gray-500 hover:text-gray-300 transition-colors z-10"
         >
-          <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-          </svg>
+          <IconClose className="w-5 h-5" />
         </button>
 
         <div className="p-6 space-y-5">
@@ -194,9 +191,7 @@ function AppContent() {
           className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
           title="Quick Start"
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-          </svg>
+          <IconBook className="w-4 h-4" />
           <span className="text-xs">Quick Start</span>
         </button>
         <div className="flex-1" />
@@ -205,9 +200,7 @@ function AppContent() {
           className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
           title="How It Works"
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-          </svg>
+          <IconLightbulb className="w-4 h-4" />
           <span className="text-xs">How It Works</span>
         </button>
         <button
@@ -215,9 +208,7 @@ function AppContent() {
           className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
           title="Troubleshooting Guide"
         >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
+          <IconInfoCircle className="w-4 h-4" />
           <span className="text-xs">Troubleshooting</span>
         </button>
         <button
@@ -225,10 +216,7 @@ function AppContent() {
           className="flex items-center gap-1.5 text-gray-500 hover:text-gray-300 transition-colors px-2 py-1 rounded hover:bg-gray-800"
           title="About Spanright"
         >
-          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
-            <circle cx="12" cy="12" r="10" />
-            <path strokeLinecap="round" d="M12 16v-4m0-4h.01" />
-          </svg>
+          <IconInfoCircle className="w-4 h-4" />
           <span className="text-xs">About</span>
         </button>
       </header>

--- a/src/canvasConstants.ts
+++ b/src/canvasConstants.ts
@@ -1,0 +1,15 @@
+/**
+ * Physical canvas workspace bounds in inches (~12 ft × 8 ft).
+ * Used for pan/zoom limits and for centering preloaded layouts.
+ */
+export const PHYS_MIN_X = 0
+export const PHYS_MAX_X = 144
+export const PHYS_MIN_Y = 0
+export const PHYS_MAX_Y = 96
+
+export const CANVAS_PHYSICAL_WIDTH_IN = PHYS_MAX_X - PHYS_MIN_X
+export const CANVAS_PHYSICAL_HEIGHT_IN = PHYS_MAX_Y - PHYS_MIN_Y
+
+/** Canvas center in inches; preloaded layouts are centered here. */
+export const CANVAS_CENTER_X_IN = (PHYS_MIN_X + PHYS_MAX_X) / 2
+export const CANVAS_CENTER_Y_IN = (PHYS_MIN_Y + PHYS_MAX_Y) / 2

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useStore } from '../store'
 import { buildShareUrl } from '../urlLayout'
 import { useToast } from './Toast'
+import { IconCheckSimple, IconShare } from '../icons'
 
 export default function ShareButton() {
   const { state } = useStore()
@@ -38,23 +39,15 @@ export default function ShareButton() {
     <button
       onClick={handleShare}
       disabled={!hasMonitors}
-      className={`text-xs px-2.5 py-1 rounded border transition-colors disabled:opacity-40 disabled:cursor-default ${
+      className={`text-xs px-2.5 py-1 rounded border transition-colors disabled:opacity-40 disabled:cursor-default min-w-[7rem] justify-center ${
         copied
           ? 'bg-green-600/20 text-green-400 border-green-500/50'
           : 'bg-gray-800 text-gray-500 border-gray-700 hover:text-gray-300'
       }`}
       title={hasMonitors ? 'Copy shareable link to clipboard' : 'Add monitors to share'}
     >
-      <span className="flex items-center gap-1.5">
-        {copied ? (
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-          </svg>
-        ) : (
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
-          </svg>
-        )}
+      <span className="flex items-center gap-1.5 justify-center">
+        {copied ? <IconCheckSimple className="w-3.5 h-3.5" /> : <IconShare className="w-3.5 h-3.5" />}
         {copied ? 'Copied!' : 'Share Layout'}
       </span>
     </button>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -27,13 +27,7 @@ export default function Toolbar() {
 
   return (
     <div className="bg-gray-900 border-b border-gray-800 px-4 h-11 flex items-center gap-4 flex-wrap">
-      {/* Saved Layouts — always leftmost */}
-      <ConfigManager />
-
-      {/* Separator */}
-      <div className="w-px h-5 bg-gray-700" />
-
-      {/* Image upload / image details */}
+      {/* Image upload / image details — leftmost */}
       <ImageUpload />
 
       {/* Monitor count and recommended (related — em dash, no extra spacer) */}
@@ -65,6 +59,10 @@ export default function Toolbar() {
 
       {/* Spacer */}
       <div className="flex-1" />
+
+      <div className="w-px h-5 bg-gray-700" />
+      {/* Saved Layouts — right side, left of Share */}
+      <ConfigManager />
 
       {/* Share layout */}
       <ShareButton />

--- a/src/components/TroubleshootingGuide.tsx
+++ b/src/components/TroubleshootingGuide.tsx
@@ -97,7 +97,7 @@ function WindowsContent() {
             Look at the <strong className="text-gray-100">Y</strong> and <strong className="text-gray-100">Height</strong> values. If Y is anything other than 0, or Height is larger than your tallest monitor's vertical resolution, one of your monitors is offset.
           </p>
           <p className="text-sm text-gray-300 leading-relaxed">
-            <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display. Carefully drag your monitors so they're perfectly aligned. The snap behavior can sometimes leave a few pixels of offset — zoom in and adjust carefully. Then re-run the PowerShell command to verify.
+            <strong className="text-gray-100">To fix:</strong> Open Settings &gt; System &gt; Display. Carefully drag your monitors so they're perfectly aligned. One trick: align as best you can, then drag one monitor slightly inside the other; when it snaps back to the edge, it will be aligned perfectly. Re-run the PowerShell command to verify.
           </p>
           <p className="text-xs text-gray-400 leading-relaxed">
             If you'd rather not adjust your display arrangement (since it affects cursor movement between screens), just use <strong className="text-gray-300">Tile</strong> mode instead of Span, which bypasses this issue entirely.

--- a/src/components/WindowsArrangementCanvas.tsx
+++ b/src/components/WindowsArrangementCanvas.tsx
@@ -401,7 +401,11 @@ export default function WindowsArrangementCanvas() {
         : verticalMismatch
           ? 'vertical alignment differs'
           : 'horizontal alignment differs'
-      warns.push(`Your ${axis} from your physical layout. The wallpaper will match your virtual layout, which may not look physically seamless.`)
+          warns.push(
+            `Your virtual layout's ${axis} from your physical layout. ` +
+            `This affects cursor movement across monitors and where black bars land when monitors have different resolutions — ` +
+            `don't worry, they only fill hidden negative space and won't be visible on your screens.`
+          )
     }
 
     return warns
@@ -452,9 +456,7 @@ export default function WindowsArrangementCanvas() {
       {state.useWindowsArrangement && (
         <div className="shrink-0 px-4 py-2.5 bg-amber-950/70 border-b border-amber-700/50 space-y-1">
           <p className="text-xs text-amber-200">
-            <strong>Note:</strong> Changing your OS display settings (position, order, resolution) can get messy.
-            For best results, align monitor edges (e.g. top-aligned side-by-side, or stacked vertically with left/right edges aligned).
-            Black bars are normal in some setups, but misaligned arrangements may produce visible black bars in the spanned wallpaper.
+            <strong>Tip:</strong> Match this to your OS display arrangement.
             {' '}<button onClick={() => dispatch({ type: 'SET_SHOW_HOW_IT_WORKS', value: true })} className="text-amber-300 underline underline-offset-2 hover:text-amber-100 transition-colors">Learn more</button>
           </p>
         </div>

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -1,0 +1,148 @@
+/**
+ * Shared SVG icon components. Use these instead of inline SVGs for consistency
+ * and easier updates. All accept optional className and other SVG props.
+ */
+
+import type { SVGProps } from 'react'
+
+const iconClass = 'shrink-0'
+
+/** Close / X (modal, toast, delete) */
+export function IconClose(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 20 20" fill="currentColor" {...props}>
+      <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+    </svg>
+  )
+}
+
+/** Chevron down (accordion, dropdown) */
+export function IconChevronDown(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  )
+}
+
+/** Bookmark / saved layouts */
+export function IconBookmark(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+    </svg>
+  )
+}
+
+/** Plus (add / save new) */
+export function IconPlus(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+    </svg>
+  )
+}
+
+/** Trash / delete */
+export function IconTrash(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+    </svg>
+  )
+}
+
+/** Kebab / three dots vertical (menu) */
+export function IconKebabVertical(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 16 16" fill="currentColor" {...props}>
+      <circle cx="8" cy="3" r="1.5" />
+      <circle cx="8" cy="8" r="1.5" />
+      <circle cx="8" cy="13" r="1.5" />
+    </svg>
+  )
+}
+
+/** Undo */
+export function IconUndo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M3 10h10a5 5 0 0 1 0 10H9" />
+      <polyline points="7 14 3 10 7 6" />
+    </svg>
+  )
+}
+
+/** Redo */
+export function IconRedo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M21 10H11a5 5 0 0 0 0 10h4" />
+      <polyline points="17 14 21 10 17 6" />
+    </svg>
+  )
+}
+
+/** Check / confirm */
+export function IconCheck(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <polyline points="3 8 7 12 13 4" />
+    </svg>
+  )
+}
+
+/** Share / link (copy URL) */
+export function IconShare(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+    </svg>
+  )
+}
+
+/** Check (success / copied) */
+export function IconCheckSimple(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  )
+}
+
+/** Info (tooltips, callouts) */
+export function IconInfo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  )
+}
+
+/** Open book (Quick Start, docs) */
+export function IconBook(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+    </svg>
+  )
+}
+
+/** Lightbulb (How it works, ideas) */
+export function IconLightbulb(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+    </svg>
+  )
+}
+
+/** Info circle (About, troubleshooting — circle with i) */
+export function IconInfoCircle(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path strokeLinecap="round" d="M12 16v-4m0-4h.01" />
+    </svg>
+  )
+}

--- a/src/preloadedLayouts.ts
+++ b/src/preloadedLayouts.ts
@@ -1,0 +1,28 @@
+/**
+ * Preloaded layout presets. Users can generate a layout in the app, use "Share Layout"
+ * to copy the URL, then provide the encoded part (the value of the `layout` hash param)
+ * to add here. Each entry is { name, encoded }; encoded is the base64url string from
+ * the share URL (e.g. from #layout=ENCODED). Leave encoded empty to hide that slot.
+ */
+import { decodeLayout, type LayoutEntry } from './urlLayout'
+
+export interface PreloadedLayout {
+  name: string
+  /** Base64url-encoded layout from share URL (#layout=...). Empty = slot unused. */
+  encoded: string
+}
+
+/** All preloaded layouts are centered at canvas center (see CANVAS_CENTER_*_IN in canvasConstants.ts). */
+export const PRELOADED_LAYOUTS: PreloadedLayout[] = [
+  { name: '15.6" Laptop + Vertical 24" Monitor', encoded: 'eyJ2IjoxLCJtIjpbeyJuIjoiMTUuNlwiIExhcHRvcCBGSEQiLCJkIjoxNS42LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjU5LjA2MjcsInkiOjUwLjQxNzEsImJ6IjpbOCwxOCw1LDVdfSx7Im4iOiIyNFwiIEZIRCIsImQiOjI0LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjczLjE3MTEsInkiOjM3LjU0MTEsInJvdCI6OTAsImJ6IjpbOCw4LDgsOF19XX0' },
+  { name: '15.6" Laptop + 2 24" Monitors', encoded: 'eyJ2IjoxLCJtIjpbeyJuIjoiMTUuNlwiIExhcHRvcCBGSEQiLCJkIjoxNS42LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjQzLjcxMywieSI6NTAuMzc0MSwiYnoiOls4LDE4LDUsNV19LHsibiI6IjI0XCIgRkhEIiwiZCI6MjQsImFyIjpbMTYsOV0sInJ4IjoxOTIwLCJyeSI6MTA4MCwieCI6NTcuODIxNCwieSI6MzcuOTc3OSwiYnoiOls4LDgsOCw4XX0seyJuIjoiMjRcIiBGSEQiLCJkIjoyNCwiYXIiOlsxNiw5XSwicngiOjE5MjAsInJ5IjoxMDgwLCJ4Ijo3OS4zNjkxLCJ5IjozNy45Nzc5LCJieiI6WzgsOCw4LDhdfV19' },
+  { name: '27" + 2 24" Vertical Monitors', encoded: 'eyJ2IjoxLCJtIjpbeyJuIjoiMjRcIiBGSEQiLCJkIjoyNCwiYXIiOlsxNiw5XSwicngiOjE5MjAsInJ5IjoxMDgwLCJ4Ijo4NC4zOTYyLCJ5IjozNy41NDExLCJyb3QiOjkwLCJieiI6WzgsOCw4LDhdfSx7Im4iOiIyN1wiIEZIRCIsImQiOjI3LCJhciI6WzE2LDldLCJyeCI6MTkyMCwicnkiOjEwODAsIngiOjYwLjIzMzcsInkiOjQ1LjIyMTksImJ6IjpbOCw4LDgsOF19LHsibiI6IjI0XCIgRkhEIiwiZCI6MjQsImFyIjpbMTYsOV0sInJ4IjoxOTIwLCJyeSI6MTA4MCwieCI6NDcuODM3NSwieSI6MzcuNTQxMSwicm90Ijo5MCwiYnoiOls4LDgsOCw4XX1dfQ' },
+]
+
+/**
+ * Decode a preloaded layout. Returns null if encoded is empty or invalid.
+ */
+export function decodePreloadedLayout(entry: PreloadedLayout): LayoutEntry[] | null {
+  if (!entry.encoded.trim()) return null
+  return decodeLayout(entry.encoded)
+}


### PR DESCRIPTION
## PR Summary

### Preloaded layouts (Quick layouts)
- **`src/preloadedLayouts.ts`** — Added support for 2–3 optional preloaded layout presets. Each entry has `name` and `encoded` (base64url from the share URL `#layout=...`). Empty `encoded` hides the slot.
- **ConfigManager** — When any preloaded layout has valid `encoded` data, a **Quick layouts** section appears at the top of the Saved Layouts dropdown; clicking a quick layout loads it like a saved layout.
- **Centering** — Preloaded layouts are centered at the canvas center (72, 48) in so they load in a consistent place. Canvas size and center come from **`src/canvasConstants.ts`** (144×96 in, center 72×48).
- **`scripts/center-preloaded-layouts.mjs`** — One-off Node script to decode layout strings, center each at the canvas center, and re-encode. Run when adding or updating preloaded layouts; paste the printed strings into `preloadedLayouts.ts`. Documented as a dev-only CLI tool (not part of the app bundle).

### Set Bezels
- **Toast** — A success toast is shown when bezels are applied or removed (“Bezels updated” / “Bezels removed”).
- **Dialog behavior** — Preset and numeric inputs **preview live** on the canvas. Changes are **committed only** when the user clicks the **✓** button or **Remove bezels**. Closing with ✕, clicking outside, or Escape **reverts** to the values from when the dialog opened (no toast).

### Monitor and image kebab menus
- **Monitor** — When a monitor is selected, a **⋮** (kebab) button appears to the left of the **✕** delete button. Clicking it opens the same context menu as right-click: Set Bezels, Rename, Rotate 90°, Delete.
- **Source image** — When the source image is selected, a **⋮** kebab appears to the left of the **✕** remove button. Its menu offers **Size image to fit** and **Remove image**.

### Toolbar
- **Saved Layouts** was moved to the **right** side of the toolbar, with a separator, **left of Share Layout** (image upload and monitor info stay on the left; spacer in the middle).
- **Share Layout** button has a fixed **min-width** so it doesn’t shrink when the label changes to “Copied!” and the toolbar layout stays stable.

### Troubleshooting and copy
- **Windows — “I see a few pixels of overflow”** — Replaced the “zoom in and adjust carefully” step (zoom isn’t available on that screen) with: align as best you can, then drag one monitor slightly inside the other; when it snaps back to the edge, it will be aligned. Re-run the PowerShell check to verify.
- **Virtual layout warning** — The message now explains that the wallpaper will match your virtual layout and that **cursor movement and window dragging** between monitors will follow that arrangement (removed “may not look physically seamless”).

### Shared icons
- **`src/icons.tsx`** — New shared SVG icon components (e.g. `IconClose`, `IconBookmark`, `IconUndo`, `IconKebabVertical`, `IconShare`, `IconBook`, `IconLightbulb`, `IconInfoCircle`) with optional `className` and SVG props. Replaced inline SVGs in **ConfigManager**, **ShareButton**, **EditorCanvas** (undo/redo, canvas kebab, bezel check), and **App.tsx** (About/Welcome close, Quick Start, How it works, Troubleshooting, About) so icons are consistent and easier to update.

### Canvas constants
- **`src/canvasConstants.ts`** — Single source of truth for physical canvas bounds in inches: `PHYS_MIN_X`, `PHYS_MAX_X`, `PHYS_MIN_Y`, `PHYS_MAX_Y` (0, 144, 0, 96), plus `CANVAS_PHYSICAL_WIDTH_IN`, `CANVAS_PHYSICAL_HEIGHT_IN`, and **`CANVAS_CENTER_X_IN`**, **`CANVAS_CENTER_Y_IN`** (72, 48). **EditorCanvas** imports these instead of local magic numbers; the centering script documents that its target (72, 48) must match this file.