### PR TITLE
Customizable fill for gaps / black bars (+ eyedropper for color)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ dist-ssr
 *.sw?
 
 .cursor/**
+.claude/**
 .specstory/**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Spanright operates in **physical space** (inches/cm), so you arrange monitors as
 - **Right-click or kebab menu** — Right-click any monitor, or when a monitor is selected click the **⋮** (kebab) button next to the **✕** delete button, for **Set Bezels**, **Rename**, **Rotate 90°**, and **Delete**. Bezels are optional per-edge borders (in mm) that extend outward from the display area; they help with alignment and matching real bezels, and Align Assist snaps to outer bezel edges when set.
 - **Image placement** — Upload a source image and drag/scale it behind the monitor layout. Semi-transparent monitor overlays let you see exactly what portion of the image each screen will display. Vertical images (height > width) default to 6 ft tall; horizontal ones default to 6 ft wide.
 - **Smart image recommendations** — Calculates the minimum source image resolution needed based on your layout's physical size and the highest-PPI monitor.
-- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's virtual layout position (side-by-side, stacked, or mixed). Fills any gaps in the layout with black.
+- **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's virtual layout position (side-by-side, stacked, or mixed). Gaps in the layout use a configurable fill: solid color (default black), blurred edge extension, or transparent (PNG only).
 - **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
 - **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom (up to 400%), right-click drag to pan. Custom scrollbars, Align Assist guides/snapping, and fit-to-view.
 - **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, bezels, virtual layout). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Optional **Quick layouts** (preloaded in code) appear at the top of the Saved Layouts dropdown when configured. The Saved Layouts control sits on the right side of the toolbar, to the left of Share Layout.
@@ -83,12 +83,14 @@ Drag monitors on the canvas to match your physical desk arrangement:
 
 ### 4. Virtual Layout (optional)
 
-The **Virtual Layout** tab (next to Physical Layout) lets you match how your OS sees your displays. Use it if your display order or positions don't match a simple left-to-right layout. This concept applies on all platforms — Windows, macOS, and Linux all maintain their own display arrangement.
+The **Virtual Layout** tab (next to Physical Layout) lets you match how your OS sees your displays. The OS arrangement defines the *virtual desktop*: where the cursor and windows move between monitors (e.g. one display above the other means the cursor crosses at the shared top edge; side-by-side at the vertical edge). Use the Virtual Layout tab if your display order or positions don't match a simple left-to-right layout. This concept applies on all platforms — Windows, macOS, and Linux all maintain their own display arrangement.
+
+The output image has the same bounding box. The OS paints the wallpaper from the top-left; each monitor only displays the rectangle of the image at its position. So any empty area in the image (gaps from different resolutions or offsets) lies outside every monitor's rectangle and is never shown on any screen.
 
 #### Windows
 Open **Settings > System > Display** to see how Windows arranges your monitors. If the order matches a simple left-to-right layout, you can skip this step.
 
-> **Warning:** Changing Windows Display Settings (position, order, resolution) can get messy. For best results, keep all monitors **top-aligned or bottom-aligned** in Windows; other alignments may produce unwanted (visible) black bars in the spanned wallpaper.
+> **Warning:** Changing Windows Display Settings (position, order, resolution) can get messy. For best results, keep all monitors **top-aligned or bottom-aligned** in Windows; other alignments may produce unwanted visible empty area in the spanned wallpaper.
 
 #### macOS
 Open **System Settings > Displays > Arrange** to see your display arrangement. Drag the display rectangles to match your physical layout.
@@ -104,7 +106,8 @@ Display arrangement depends on your desktop environment:
 ### 5. Preview & Export
 
 - The bottom panel shows a live preview of the final stitched wallpaper
-- Click **Download** to save as PNG or JPEG
+- When the output has empty area (e.g. vertical offsets or different strip heights), use **Empty area options** to choose how to fill it: **Solid color** (with color picker and eyedropper to sample from the source image), **Blurred edge extension**, or **Transparent** (PNG only)
+- Click **Download** to save as PNG or JPEG (transparent fill forces PNG)
 - The output dimensions are displayed (e.g., "7280 x 1440")
 
 ### 6. Set Your Wallpaper
@@ -188,7 +191,7 @@ Output matches the virtual desktop bounding box of your virtual layout. For each
 2. **Virtual layout** (pixel positions) determines where the monitor sits in the output image.
 3. The source image is cropped and scaled to the monitor's native resolution (PPI-correct).
 4. Each monitor is drawn at its `(pixelX, pixelY)` position in the output. This supports side-by-side, stacked vertical, and mixed layouts.
-5. Output dimensions = bounding box of all monitors (`maxX − minX` × `maxY − minY`). Any unfilled area (gaps or differing sizes) is filled with black.
+5. Output dimensions = bounding box of all monitors (`maxX − minX` × `maxY − minY`). Any unfilled area uses the chosen fill mode: solid color (default black), blurred edge extension, or transparent (PNG only).
 
 ## Tech Stack
 

--- a/src/components/InfoDialog.tsx
+++ b/src/components/InfoDialog.tsx
@@ -60,16 +60,28 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
             </div>
           </section>
 
-          {/* Illustration */}
+          {/* Virtual layout in detail: what it controls and why empty area doesn't show */}
+          <section className="space-y-2 bg-gray-800/30 border border-gray-700/50 rounded-lg p-3">
+            <h3 className="text-sm font-medium text-gray-200">Virtual layout in detail</h3>
+            <p className="text-xs text-gray-400 leading-relaxed">
+              Your OS display arrangement defines the <strong className="text-gray-300">virtual desktop</strong>: where the cursor and windows move between monitors. If one display is above the other, the cursor crosses at the shared top edge; side-by-side, at the vertical edge between them. Offsets change where that &quot;seam&quot; is. Matching the Virtual Layout tab to your OS ensures the output image lines up with how the OS will paint it.
+            </p>
+            <p className="text-xs text-gray-400 leading-relaxed mt-2">
+              <strong className="text-gray-300">Why empty area doesn&apos;t show:</strong> The OS (Windows, macOS, Linux) paints the wallpaper from the top-left over that bounding box. Each monitor only displays the rectangle of the image at its position — so only pixels that fall inside a monitor&apos;s rectangle are ever shown on a screen. Gaps in the image (from different resolutions or vertical offsets) lie outside every monitor&apos;s rectangle, so no physical display ever shows them. You only see the parts that map to your actual monitors.
+            </p>
+          </section>
+
+          {/* Illustration: Your desk → Your OS sees (same resolution = two identical rectangles) */}
           <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
-            <div className="flex items-center justify-center gap-6">
+            <div className="flex items-center justify-center gap-6 flex-wrap">
               <div className="text-center">
                 <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Your desk</div>
                 <div className="relative w-32 h-16">
-                  <div className="absolute left-0 bottom-0 w-12 h-9 border border-cyan-500/60 bg-cyan-500/10 rounded-sm flex items-center justify-center">
+                  {/* 16:9 each — laptop smaller, monitor larger */}
+                  <div className="absolute left-0 bottom-0 w-12 border border-cyan-500/60 bg-cyan-500/10 rounded-sm flex items-center justify-center" style={{ height: 27 }}>
                     <span className="text-[8px] text-cyan-400">Laptop</span>
                   </div>
-                  <div className="absolute left-14 top-0 w-18 h-14 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center">
+                  <div className="absolute left-14 top-0 w-16 h-9 border border-blue-500/60 bg-blue-500/10 rounded-sm flex items-center justify-center">
                     <span className="text-[8px] text-blue-400">Monitor</span>
                   </div>
                 </div>
@@ -79,19 +91,40 @@ export default function InfoDialog({ onClose }: InfoDialogProps) {
 
               <div className="text-center">
                 <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2">Your OS sees</div>
-                <div className="inline-block overflow-visible p-px">
-                  <div className="flex gap-px items-stretch">
-                    <div className="shrink-0 w-10 h-10 border border-cyan-500/60 bg-cyan-500/10 rounded-l-md rounded-r-sm flex items-center justify-center">
-                      <span className="text-[8px] text-cyan-400">1</span>
-                    </div>
-                    <div className="shrink-0 w-[72px] h-10 border border-blue-500/60 bg-blue-500/10 rounded-r-md rounded-l-sm flex items-center justify-center">
-                      <span className="text-[8px] text-blue-400">2</span>
-                    </div>
+                <div className="flex gap-px items-stretch">
+                  {/* Same 16:9 aspect ratio as desk rectangles; two identical (same resolution) */}
+                  <div className="shrink-0 border border-cyan-500/60 bg-cyan-500/10 rounded-l-md rounded-r-sm flex items-center justify-center" style={{ width: 40, height: 22.5 }}>
+                    <span className="text-[8px] text-cyan-400">1</span>
+                  </div>
+                  <div className="shrink-0 border border-blue-500/60 bg-blue-500/10 rounded-r-md rounded-l-sm flex items-center justify-center" style={{ width: 40, height: 22.5 }}>
+                    <span className="text-[8px] text-blue-400">2</span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+
+          {/* Illustration 2 (hidden — user will explain via YouTube): bounding box and empty area when resolutions/offsets differ */}
+          {false && (
+            <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+              <div className="text-[10px] text-gray-500 uppercase tracking-wider mb-2 text-center">Different resolutions or offset → bounding box has empty area</div>
+              <div className="flex justify-center">
+                <div className="relative rounded" style={{ width: 112, height: 76 }}>
+                  <div className="absolute inset-0 border-2 border-dashed border-amber-500/50 rounded" />
+                  <div className="absolute left-0 top-0 border border-cyan-500/60 bg-cyan-500/10 rounded-tl flex items-center justify-center" style={{ width: 56, height: 56 }}>
+                    <span className="text-[8px] text-cyan-400">1</span>
+                  </div>
+                  <div className="absolute left-[56px] top-5 border border-blue-500/60 bg-blue-500/10 rounded-tr flex items-center justify-center" style={{ width: 56, height: 56 }}>
+                    <span className="text-[8px] text-blue-400">2</span>
+                  </div>
+                  <div className="absolute left-14 top-0 w-14 h-5 bg-gray-600/70 rounded-b flex items-center justify-center">
+                    <span className="text-[7px] text-gray-400 leading-tight text-center">Empty area</span>
+                  </div>
+                </div>
+              </div>
+              <p className="text-[9px] text-gray-500 mt-2 text-center">Output image = full dashed box; each monitor only shows its rectangle. The gap is never displayed.</p>
+            </div>
+          )}
 
           {/* Step 3 */}
           <section className="space-y-2">

--- a/src/components/MonitorPresetsSidebar.tsx
+++ b/src/components/MonitorPresetsSidebar.tsx
@@ -127,13 +127,15 @@ export default function MonitorPresetsSidebar() {
   const standard = filtered.filter(p => p.diagonal >= 20 && p.aspectRatio[0] === 16)
   const ultrawides = filtered.filter(p => p.aspectRatio[0] >= 21)
 
-  const [collapsed, setCollapsed] = useState(false)
+  const collapsed = state.presetsSidebarCollapsed
 
-  if (collapsed) {
+  // When eyedropper is active we show the collapsed UI (so canvas has room); collapsed state lives in store so it persists across tab switch.
+  if (collapsed || state.eyedropperActive) {
     return (
       <button
-        onClick={() => setCollapsed(false)}
-        className="absolute top-8 left-8 z-30 flex items-center gap-1.5 bg-gray-800/90 hover:bg-gray-700 border border-gray-600/50 hover:border-gray-500 backdrop-blur-sm text-gray-300 hover:text-white text-xs font-medium px-2.5 py-1.5 rounded-md shadow-lg transition-all"
+        onClick={() => !state.eyedropperActive && dispatch({ type: 'SET_PRESETS_SIDEBAR_COLLAPSED', collapsed: false })}
+        disabled={state.eyedropperActive}
+        className="absolute top-8 left-8 z-30 flex items-center gap-1.5 bg-gray-800/90 hover:bg-gray-700 border border-gray-600/50 hover:border-gray-500 backdrop-blur-sm text-gray-300 hover:text-white text-xs font-medium px-2.5 py-1.5 rounded-md shadow-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-800/90 disabled:hover:border-gray-600/50"
       >
         <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
           <path fillRule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clipRule="evenodd" />
@@ -153,7 +155,7 @@ export default function MonitorPresetsSidebar() {
               Add a Monitor
             </h2>
             <button
-              onClick={() => setCollapsed(true)}
+              onClick={() => dispatch({ type: 'SET_PRESETS_SIDEBAR_COLLAPSED', collapsed: true })}
               className="text-gray-500 hover:text-gray-300 transition-colors p-0.5 -mr-1"
               title="Collapse sidebar"
             >

--- a/src/components/WindowsArrangementCanvas.tsx
+++ b/src/components/WindowsArrangementCanvas.tsx
@@ -401,11 +401,7 @@ export default function WindowsArrangementCanvas() {
         : verticalMismatch
           ? 'vertical alignment differs'
           : 'horizontal alignment differs'
-          warns.push(
-            `Your virtual layout's ${axis} from your physical layout. ` +
-            `This affects cursor movement across monitors and where black bars land when monitors have different resolutions — ` +
-            `don't worry, they only fill hidden negative space and won't be visible on your screens.`
-          )
+      warns.push(`Your virtual layout's ${axis} from your physical layout.`)
     }
 
     return warns
@@ -452,12 +448,13 @@ export default function WindowsArrangementCanvas() {
 
       </div>
 
-      {/* Baseline warning when customizing — in flow so it’s always visible */}
+      {/* Explanation when customizing (purpose of OS arrangement and empty area) — in flow so it’s always visible */}
       {state.useWindowsArrangement && (
-        <div className="shrink-0 px-4 py-2.5 bg-amber-950/70 border-b border-amber-700/50 space-y-1">
+        <div className="shrink-0 px-4 py-2.5 bg-amber-950/70 border-b border-amber-700/50">
           <p className="text-xs text-amber-200">
-            <strong>Tip:</strong> Match this to your OS display arrangement.
-            {' '}<button onClick={() => dispatch({ type: 'SET_SHOW_HOW_IT_WORKS', value: true })} className="text-amber-300 underline underline-offset-2 hover:text-amber-100 transition-colors">Learn more</button>
+            <strong>Tip:</strong> Match this to your OS display arrangement. Arrangement on this page affects the output image.
+            {' '}For more information on how virtual layout works,{' '}
+            <button onClick={() => dispatch({ type: 'SET_SHOW_HOW_IT_WORKS', value: true })} className="text-amber-300 underline underline-offset-2 hover:text-amber-100 transition-colors">see How It Works</button>.
           </p>
         </div>
       )}

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -146,3 +146,13 @@ export function IconInfoCircle(props: SVGProps<SVGSVGElement>) {
     </svg>
   )
 }
+
+/** Eyedropper / pipette (sample color from image) — thick diagonal stem (two lines, rounded) with bulb circle */
+export function IconEyedropper(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg className={iconClass} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M6 20L15 6L17 6L8 20Z" />
+      <circle cx="18" cy="6" r="3.5" fill="currentColor" />
+    </svg>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,9 @@ export interface WindowsMonitorPosition {
 
 export type ActiveTab = 'physical' | 'windows' | 'preview'
 
+/** How to fill empty area (output regions not covered by the source image). */
+export type FillMode = 'solid' | 'blur' | 'transparent'
+
 export interface SavedConfig {
   id: string
   name: string


### PR DESCRIPTION
## Summary

Adds **customizable empty-area fill** for the stitched wallpaper output (resolves #26) and improves UX around the eyedropper and Add a Monitor sidebar.

## Features

### Empty area fill
- **Fill modes:** **Solid color** (default black), **Blurred edge extension**, or **Transparent** (PNG only). Chosen in Preview via **Empty area options** (toolbar, left of format dropdown).
- **Solid color:** Color picker, preset swatches, and **eyedropper** to sample from the source image on the Physical Layout canvas.
- Empty area options are always visible; when there’s no empty area they’re disabled with a tooltip. Copy explains that empty area is normal for offset/mixed-resolution layouts and isn’t shown on any physical display.
- Wording standardized to **“empty area”** in UI and docs.

### Eyedropper
- Activate from the Empty area options popover (solid fill). Click on the source image to set the fill color; app switches to Preview after a successful pick. **Escape** cancels without applying.
- While active: crosshair cursor, canvas layer non-interactive (no monitor/image drag), undo/redo and canvas kebab disabled, monitor and image menus closed. Clicking outside the canvas (tabs, toolbar, etc.) exits eyedropper. Eyedropper turns off when leaving the Physical Layout tab.
- **Add a Monitor** sidebar shows collapsed when eyedropper is on (button disabled) so the canvas stays usable.

### Persisted sidebar state
- **Add a Monitor** collapsed/expanded state is stored in the app state (`presetsSidebarCollapsed`) so it survives tab changes. Returning to Physical Layout after using the eyedropper (and switching to Preview) no longer reopens the full sidebar if it was collapsed.

### Icon
- **Eyedropper icon** updated to a pipette: thick diagonal stem (two lines, rounded) and filled circle for the bulb.

## Technical

- **Store:** `fillMode`, `fillSolidColor`, `eyedropperActive`, `presetsSidebarCollapsed`; actions for each. On `SET_ACTIVE_TAB` to a tab other than `physical`, `eyedropperActive` is cleared.
- **Output pipeline** (`generateOutput.ts`): `FillSettings` (mode + solidColor); solid/blur/transparent handling; `rotatedImageCanvas` used for correct sampling with image rotation.
- **EditorCanvas:** Eyedropper mousedown samples from the rotated image canvas, applies fill color and mode, then switches to Preview; document mousedown outside canvas container exits eyedropper.
- **MonitorPresetsSidebar:** Reads/writes `presetsSidebarCollapsed` from store instead of local state; shows collapsed when `collapsed || eyedropperActive`.

## Docs
- **README:** Features list and Directions §5 (Preview & Export) updated for empty area options (solid with picker/eyedropper, blur, transparent).
- **InfoDialog:** “Empty area” and “empty area doesn’t show” wording aligned with the new options and behavior.