### PR TITLE
Added image position saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Spanright operates in **physical space** (inches/cm), so you arrange monitors as
 - **Accurate output generation** — Crops and scales the source image per-monitor at each screen's native PPI, then stitches at each monitor's virtual layout position (side-by-side, stacked, or mixed). Gaps in the layout use a configurable fill: solid color (default black), blurred edge extension, or transparent (PNG only).
 - **Preview & download** — Live preview of the final stitched wallpaper with one-click PNG/JPEG export.
 - **Canvas controls** — Scroll to pan, Ctrl+Scroll to zoom (up to 400%), right-click drag to pan. Custom scrollbars, Align Assist guides/snapping, and fit-to-view.
-- **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, bezels, virtual layout). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Optional **Quick layouts** (preloaded in code) appear at the top of the Saved Layouts dropdown when configured. The Saved Layouts control sits on the right side of the toolbar, to the left of Share Layout.
+- **Saved Layouts** — Save and load monitor layouts (names, positions, rotation, bezels, virtual layout). Saving a layout also stores the current image position when an image is loaded; loading a layout and then uploading an image applies that saved position (with aspect-ratio adaptation). Layouts are stored in your browser (localStorage); you can keep several setups (e.g. desk vs laptop-only) and switch between them. Optional **Quick layouts** (preloaded in code) appear at the top of the Saved Layouts dropdown when configured. The Saved Layouts control sits on the right side of the toolbar, to the left of Share Layout.
+- **Image position bookmark** — Right-click the source image for **Bookmark image position**, **Apply bookmarked position**, and **Clear bookmarked position**. The bookmark is stored per layout name (or "_default" when no layout is active) so you can pin a preferred image position independently of saving the full layout.
 - **Cross-platform** — Works in any modern browser. Output can be applied as a spanned wallpaper on Windows (Span/Tile mode), macOS (per-monitor crop), and Linux (varies by DE — GNOME, KDE, feh, swaybg, etc.).
 
 ## Example
@@ -64,7 +65,7 @@ Drag monitors on the canvas to match your physical desk arrangement:
 - Position your laptop screen lower-left, your main monitor centered, etc.
 - The canvas uses physical dimensions — a 27" monitor will appear larger than a 13" laptop
 - **Right-click** a monitor, or select it and click the **⋮** kebab next to the **✕**, for the context menu: **Set Bezels**, **Rename**, **Rotate 90°**, or **Delete**. Bezels extend outward from the display area; Align Assist snaps to outer bezel edges when bezels are set.
-- When the **source image** is selected, use the **⋮** kebab (next to **✕**) for **Size image to fit** or **Remove image**.
+- When the **source image** is selected, use the **⋮** kebab or **right-click** the image for **Size image to fit**, **Bookmark image position**, **Apply bookmarked position** (when a bookmark exists), **Clear bookmarked position**, and **Remove image**.
 - Use **Align Assist** (canvas menu) for dynamic edge/center alignment guides while dragging monitors
 - Use the **↻** (rotate) button on a monitor, or **Rotate 90°** from the right-click menu, to switch between landscape and portrait
 - Click a monitor and press **Delete** (or use the context menu) to remove it
@@ -74,10 +75,11 @@ Drag monitors on the canvas to match your physical desk arrangement:
 ### 3. Upload & Position Your Image
 
 - Drag and drop an image file onto the canvas, or use the upload button in the toolbar
-- The image appears behind the monitors with 70% opacity
+- The image appears behind the monitors with 70% opacity. If you loaded a layout that had a saved image position, the next image you upload is automatically positioned from that layout (with aspect-ratio adaptation); a toast confirms "Image positioned from saved layout"
 - **Drag** the image to reposition it
 - **Click** the image and use the corner handles to resize it
-- Use **Size image to fit** from the canvas menu (top-right ⋮) or from the **⋮** kebab on the source image when selected
+- Use **Size image to fit** from the canvas menu (top-right ⋮) or from the **⋮** kebab / right-click menu on the source image
+- **Right-click** the image for **Bookmark image position**, **Apply bookmarked position**, or **Clear bookmarked position**
 - With **Align Assist** enabled, image drag/resize shows green alignment guides against monitor edges/centers
 - Check the **recommended image size** banner in the toolbar — green means your image is large enough, yellow/red means it may appear pixelated
 

--- a/src/imagePositionStorage.ts
+++ b/src/imagePositionStorage.ts
@@ -1,0 +1,56 @@
+import type { SavedImagePosition } from './types'
+
+export const IMAGE_POSITIONS_STORAGE_KEY = 'spanright-image-positions'
+
+export function getImagePositionBookmark(layoutKey: string): SavedImagePosition | null {
+  try {
+    const raw = localStorage.getItem(IMAGE_POSITIONS_STORAGE_KEY)
+    const map = raw ? (JSON.parse(raw) as Record<string, SavedImagePosition>) : {}
+    return map[layoutKey] ?? null
+  } catch {
+    return null
+  }
+}
+
+export function setImagePositionBookmark(layoutKey: string, position: SavedImagePosition): void {
+  try {
+    const raw = localStorage.getItem(IMAGE_POSITIONS_STORAGE_KEY)
+    const map = raw ? (JSON.parse(raw) as Record<string, SavedImagePosition>) : {}
+    map[layoutKey] = position
+    localStorage.setItem(IMAGE_POSITIONS_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Ignore
+  }
+}
+
+export function deleteImagePositionBookmark(layoutKey: string): void {
+  try {
+    const raw = localStorage.getItem(IMAGE_POSITIONS_STORAGE_KEY)
+    const map = raw ? (JSON.parse(raw) as Record<string, SavedImagePosition>) : {}
+    delete map[layoutKey]
+    localStorage.setItem(IMAGE_POSITIONS_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Ignore
+  }
+}
+
+const COMMON_ASPECT_LABELS: [number, string][] = [
+  [16 / 9, '16:9'],
+  [16 / 10, '16:10'],
+  [21 / 9, '21:9'],
+  [4 / 3, '4:3'],
+  [1, '1:1'],
+  [3 / 2, '3:2'],
+]
+
+const ASPECT_LABEL_TOLERANCE = 0.03
+
+/** Format aspect ratio for UI (e.g. "16:9", "1:1", or "1.78"). */
+export function formatAspectRatioLabel(aspectRatio: number): string {
+  for (const [ar, label] of COMMON_ASPECT_LABELS) {
+    if (Math.abs(ar - aspectRatio) / Math.max(ar, aspectRatio) < ASPECT_LABEL_TOLERANCE) {
+      return label
+    }
+  }
+  return aspectRatio.toFixed(2)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,15 @@ export type ActiveTab = 'physical' | 'windows' | 'preview'
 /** How to fill empty area (output regions not covered by the source image). */
 export type FillMode = 'solid' | 'blur' | 'transparent'
 
+/** Image position in physical/canvas space (for saved layouts and bookmarks). */
+export interface SavedImagePosition {
+  x: number
+  y: number
+  width: number
+  height: number
+  aspectRatio: number // width/height of the image when saved
+}
+
 export interface SavedConfig {
   id: string
   name: string
@@ -70,6 +79,8 @@ export interface SavedConfig {
     displayName?: string
     bezels?: Bezels
   }[]
+  /** Embedded image transform when layout was saved; null if no image. Omitted on older configs. */
+  imagePosition?: SavedImagePosition | null
 }
 
 export interface AppState {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,40 @@
-import type { MonitorPreset, Monitor, Bezels } from './types'
+import type { MonitorPreset, Monitor, Bezels, SavedImagePosition } from './types'
 import { v4 as uuidv4 } from 'uuid'
+
+const ASPECT_RATIO_TOLERANCE = 0.05
+
+/**
+ * Adapt a saved image position to a new aspect ratio.
+ * If aspect ratios match within tolerance, returns saved position; otherwise
+ * matches one dimension and centers on the other.
+ */
+export function adaptSavedPositionToAspectRatio(
+  saved: SavedImagePosition,
+  newAspectRatio: number
+): { x: number; y: number; width: number; height: number } {
+  const savedAR = saved.aspectRatio
+  if (Math.abs(savedAR - newAspectRatio) < ASPECT_RATIO_TOLERANCE) {
+    return { x: saved.x, y: saved.y, width: saved.width, height: saved.height }
+  }
+  if (newAspectRatio > savedAR) {
+    const newWidth = saved.width
+    const newHeight = newWidth / newAspectRatio
+    return {
+      x: saved.x,
+      y: saved.y + (saved.height - newHeight) / 2,
+      width: newWidth,
+      height: newHeight,
+    }
+  }
+  const newHeight = saved.height
+  const newWidth = newHeight * newAspectRatio
+  return {
+    x: saved.x + (saved.width - newWidth) / 2,
+    y: saved.y,
+    width: newWidth,
+    height: newHeight,
+  }
+}
 
 /**
  * Calculate PPI from resolution and diagonal size.


### PR DESCRIPTION
Resolves #49.

## Summary

Adds **persistent image position** with two independent mechanisms (layout-embedded and bookmark) and fixes “Apply from layout” so it uses the position you just saved.

## Features

### 1. Image position in saved layouts
- **Save:** Saving a layout stores the **current** canvas image position (when an image is loaded) in the layout. No extra UI.
- **Load:** Loading a layout sets that layout’s image position in state. The **next** image you upload (or replace) is placed using that position, with aspect-ratio adaptation.
- **Apply from layout:** New menu item **“Apply image position from layout”** (when the current layout has a position) applies that layout position to the current image (with adaptation). After saving a layout, we now update state so “Apply from layout” uses the position you just saved (fixes the bug where it didn’t move the image back).

### 2. Image position bookmark
- **Storage:** `spanright-image-positions` in localStorage, keyed by layout name (or `_default` when no layout is active). Independent of saved layouts.
- **Menu (right-click / kebab on image):**
  - **Bookmark image position** — Saves current image transform for the current layout key.
  - **Apply bookmarked position** — Shown when a bookmark exists; applies it with aspect-ratio adaptation.
  - **Clear bookmarked position** — Shown when a bookmark exists; removes the bookmark only (layout position unchanged).
- **Upload:** When you upload (or replace) an image, placement order is: (1) layout position if set, (2) bookmark if set, (3) 6 ft + center default. Clear bookmark and re-upload to fall back to layout position.

### 3. Apply from layout fix
- Saving a layout now dispatches `SET_LOADED_LAYOUT_IMAGE_POSITION` with the position just saved, so “Apply image position from layout” uses the current layout’s position (e.g. image on the left → save → move image → Apply from layout → image back on the left).

### 4. Wording
- All UI and docs use **“bookmark”** for the pinned position: “Bookmark image position”, “Apply bookmarked position”, “Clear bookmarked position”, and matching toasts. Keeps “saved layout” vs “bookmark” clearly distinct.

## Technical

- **Types:** `SavedImagePosition` (x, y, width, height, aspectRatio); `SavedConfig.imagePosition` optional for backward compatibility.
- **Store:** `activeLayoutName`, `loadedLayoutImagePosition`; `LOAD_LAYOUT` (layoutName, imagePosition), `SET_ACTIVE_LAYOUT_NAME`, `SET_LOADED_LAYOUT_IMAGE_POSITION`, `CLEAR_LOADED_LAYOUT_IMAGE_POSITION`.
- **ConfigManager:** Save includes current `sourceImage` as `imagePosition` and dispatches `SET_LOADED_LAYOUT_IMAGE_POSITION`; load passes `config.imagePosition`; delete removes the layout’s bookmark from `spanright-image-positions`.
- **Upload (EditorCanvas + ImageUpload):** If `loadedLayoutImagePosition` use it, else if bookmark for current key use it, else 6 ft + center; toasts for “from layout”, “from bookmark”, or “Image loaded”.
- **Aspect-ratio adaptation** (`utils.ts`): `adaptSavedPositionToAspectRatio` — match within tolerance, else match one dimension and center on the other.
- **Bookmark storage** (`imagePositionStorage.ts`): get/set/delete with try/catch; key = `activeLayoutName ?? '_default'`.

## Docs
- **README:** Features and directions updated for layout image position, bookmark (bookmark/apply/clear), and “Apply image position from layout”.